### PR TITLE
Fix chat audio focus and restore phone playback

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
+++ b/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
@@ -218,9 +218,6 @@ final class ChatVoiceModeController: ObservableObject {
 
     func preconnectDictationSTTIfNeeded() async {
         guard NetworkMonitor.shared.isOnline else { return }
-        await MainActor.run {
-            self.dictationSTTService.prewarmAudioForInstantStart()
-        }
         guard dictationSTTService.isConnected == false else { return }
         guard await delegate?.getAccessToken() != nil else { return }
         await dictationSTTService.connect()

--- a/TalkToMe/Services/Backend/SharedAudioEngine.swift
+++ b/TalkToMe/Services/Backend/SharedAudioEngine.swift
@@ -15,6 +15,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     private let audioQueue = DispatchQueue(label: "talktome.sharedAudioEngine")
     private var isConfigured = false
     private var hasSpeakerLevelTap = false
+    private var hasInputTap = false
 
     private init() {}
 
@@ -48,6 +49,7 @@ final class SharedAudioEngine: @unchecked Sendable {
             engine = eng
             isConfigured = false
             hasSpeakerLevelTap = false
+            hasInputTap = false
         }
 
         if !isConfigured {
@@ -101,6 +103,7 @@ final class SharedAudioEngine: @unchecked Sendable {
             let format = input.outputFormat(forBus: 0)
             input.removeTap(onBus: 0)
             input.installTap(onBus: 0, bufferSize: bufferSize, format: format, block: block)
+            hasInputTap = true
         }
     }
 
@@ -108,6 +111,10 @@ final class SharedAudioEngine: @unchecked Sendable {
     func removeInputTap() {
         audioQueue.sync {
             engine?.inputNode.removeTap(onBus: 0)
+            hasInputTap = false
+        }
+        audioQueue.async {
+            self.deactivateAudioSessionIfIdleOnQueue()
         }
     }
 
@@ -139,12 +146,18 @@ final class SharedAudioEngine: @unchecked Sendable {
             engine?.mainMixerNode.removeTap(onBus: 0)
             hasSpeakerLevelTap = false
         }
+        audioQueue.async {
+            self.deactivateAudioSessionIfIdleOnQueue()
+        }
     }
 
     /// Stop the player node without stopping the engine.
     func stopPlayerNode() {
         audioQueue.sync {
             playerNode.stop()
+        }
+        audioQueue.async {
+            self.deactivateAudioSessionIfIdleOnQueue()
         }
     }
 
@@ -156,10 +169,12 @@ final class SharedAudioEngine: @unchecked Sendable {
                 hasSpeakerLevelTap = false
             }
             engine?.inputNode.removeTap(onBus: 0)
+            hasInputTap = false
             playerNode.stop()
             engine?.stop()
             engine = nil
             isConfigured = false
+            deactivateAudioSessionIfIdleOnQueue()
         }
     }
 
@@ -167,6 +182,18 @@ final class SharedAudioEngine: @unchecked Sendable {
     var inputFormat: AVAudioFormat? {
         audioQueue.sync {
             engine?.inputNode.outputFormat(forBus: 0)
+        }
+    }
+
+    private func deactivateAudioSessionIfIdleOnQueue() {
+        guard !hasInputTap else { return }
+        guard !hasSpeakerLevelTap else { return }
+        guard !playerNode.isPlaying else { return }
+
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            print("[SharedAudioEngine] Audio session deactivate error: \(error.localizedDescription)")
         }
     }
 }

--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-echo "🔧 Conductor setup (real secrets)"
+echo "🔧 Conductor setup (real secrets + resources)"
 
-# Fail early if your real secrets store doesn't exist
+# Fail early if your local store doesn't exist
 if [ ! -f ~/.config/talktome/backend.env ]; then
   echo "❌ Missing ~/.config/talktome/backend.env"
   exit 1
@@ -14,17 +14,27 @@ if [ ! -f ~/.config/talktome/Secrets.plist ]; then
   exit 1
 fi
 
+if [ ! -d ~/.config/talktome/Resources ]; then
+  echo "❌ Missing ~/.config/talktome/Resources"
+  exit 1
+fi
+
 # Link Backend/.env
-if [ ! -f Backend/.env ]; then
+if [ ! -e Backend/.env ]; then
   ln -s ~/.config/talktome/backend.env Backend/.env
   echo "✔ Linked Backend/.env"
 fi
 
 # Link TalkToMe/Secrets.plist
-if [ ! -f TalkToMe/Secrets.plist ]; then
+if [ ! -e TalkToMe/Secrets.plist ]; then
   ln -s ~/.config/talktome/Secrets.plist TalkToMe/Secrets.plist
   echo "✔ Linked TalkToMe/Secrets.plist"
 fi
 
-echo "✅ Done"
+# Link Resources directory
+if [ ! -e TalkToMe/Resources ]; then
+  ln -s ~/.config/talktome/Resources TalkToMe/Resources
+  echo "✔ Linked TalkToMe/Resources"
+fi
 
+echo "✅ Done"


### PR DESCRIPTION
This PR fixes chat audio session behavior so entering chat no longer interrupts phone audio playback. It also releases AVAudioSession when mic/TTS activity ends, allowing prior audio to resume automatically. Audio-session release checks run on the audio queue to avoid UI lag during transitions. Includes the current branch changes relative to main.