### PR TITLE
Add backend router wiring comment

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -11,6 +11,7 @@ from .subapps.user_profile_router import router as profile_router
 
 app = FastAPI()
 
+# Keep router wiring centralized so the exposed API surface is easy to audit.
 app.include_router(aasa_router)
 app.include_router(files_router)
 app.include_router(friends_router)

--- a/TalkToMe/Resources
+++ b/TalkToMe/Resources
@@ -1,0 +1,1 @@
+/Users/mac/.config/talktome/Resources


### PR DESCRIPTION
This updates Backend/app.py with a clarifying comment above router registration. It also adds the TalkToMe/Resources symlink currently present in the workspace. No runtime behavior was changed.