### PR TITLE
Stabilize iOS voice mode audio and mic UI

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
+++ b/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
@@ -223,6 +223,22 @@ final class ChatVoiceModeController: ObservableObject {
         await dictationSTTService.connect()
     }
 
+    func preconnectSpeakServicesIfNeeded() async {
+        guard NetworkMonitor.shared.isOnline else { return }
+        guard await delegate?.getAccessToken() != nil else { return }
+
+        if speakSTTService.isConnected == false {
+            await speakSTTService.connect(
+                config: .init(language: "en-US", model: "nova-3", endpointingMs: 400, sampleRateHz: 24_000)
+            )
+        }
+
+        let storedVoiceId = (UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceId) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !storedVoiceId.isEmpty else { return }
+        await elevenLabsStreamingTTS.preconnect(voiceId: storedVoiceId)
+    }
+
     func startVoiceModePushToTalk() {
         if isSpeakModeActive {
             stopSpeakMode()
@@ -311,6 +327,8 @@ final class ChatVoiceModeController: ObservableObject {
             }
 
             self.speakSTTService.transcriptAggregation = .perUtterance
+            self.speakSTTService.startRecording()
+            self.updatePhase(.listening)
 
             // Connect STT and preconnect TTS in parallel
             async let sttConnect: Void = {
@@ -325,8 +343,9 @@ final class ChatVoiceModeController: ObservableObject {
             _ = await (sttConnect, ttsPreconnect)
 
             guard self.isSpeakModeActive else { return }
-            self.speakSTTService.startRecording()
-            self.updatePhase(.listening)
+            if self.speakSTTService.isConnected {
+                self.speakSTTService.lastError = nil
+            }
         }
     }
 

--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -55,7 +55,9 @@ struct ChatView: View {
                 isInputFocused: $isInputFocused
             )
             .task {
-                await viewModel.voiceController.preconnectDictationSTTIfNeeded()
+                async let dictationWarmup: Void = viewModel.voiceController.preconnectDictationSTTIfNeeded()
+                async let speakWarmup: Void = viewModel.voiceController.preconnectSpeakServicesIfNeeded()
+                _ = await (dictationWarmup, speakWarmup)
             }
             .toolbar {
                 if let onBack {

--- a/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
+++ b/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
@@ -38,15 +38,24 @@ final class TransparentPlayerUIView: UIView {
     }
 
     func configure(videoName: String, extension ext: String, loop: Bool) {
-        self.shouldLoop = loop
+        shouldLoop = loop
+
         guard let url = Bundle.main.url(forResource: videoName, withExtension: ext) else {
             print("TransparentVideoPlayer: Could not find \(videoName).\(ext)")
             return
         }
 
+        // Decorative ghost playback should never claim exclusive audio focus.
+        SharedAudioEngine.shared.ensureIdleAudioSession()
+
         let asset = AVURLAsset(url: url)
         let playerItem = AVPlayerItem(asset: asset)
+        // Disable embedded audio tracks so decorative ghost loops are strictly visual.
+        for track in playerItem.tracks where track.assetTrack?.mediaType == .audio {
+            track.isEnabled = false
+        }
         let queuePlayer = AVQueuePlayer(playerItem: playerItem)
+        queuePlayer.volume = 0
         queuePlayer.isMuted = true
         // Local file – never wait for network buffering
         queuePlayer.automaticallyWaitsToMinimizeStalling = false
@@ -69,45 +78,19 @@ final class TransparentPlayerUIView: UIView {
 
         queuePlayer.play()
 
-        guard loop else { return }
-
-        // KVO: restart if timeControlStatus becomes .paused or .waitingToPlayAtSpecifiedRate
-        statusObservation = queuePlayer.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
-            guard let self, self.shouldLoop else { return }
-            if player.timeControlStatus != .playing {
-                DispatchQueue.main.async {
-                    self.forceResume()
-                }
-            }
-        }
-
-        // KVO: restart if rate drops to 0
-        rateObservation = queuePlayer.observe(\.rate, options: [.new]) { [weak self] player, _ in
-            guard let self, self.shouldLoop else { return }
-            if player.rate == 0 {
-                DispatchQueue.main.async {
-                    self.forceResume()
-                }
-            }
-        }
-
-        // Resume playback when app returns to foreground
+        // Resume playback when app returns to foreground.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appDidBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
-
-        // Resume after audio session interruption (e.g. STT claiming the session)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAudioInterruption(_:)),
             name: AVAudioSession.interruptionNotification,
             object: nil
         )
-
-        // Resume after audio route changes
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleRouteChange),
@@ -115,51 +98,53 @@ final class TransparentPlayerUIView: UIView {
             object: nil
         )
 
-        // Heartbeat timer as ultimate safety net – checks every 0.25s
-        // Use `.common` run loop modes so it still fires during UI tracking/animations.
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            guard let self, self.shouldLoop else { return }
-            self.forceResume()
+        // Keep the ghost moving if voice mode audio/session changes pause it.
+        statusObservation = queuePlayer.observe(\.timeControlStatus, options: [.new]) { [weak self] _, _ in
+            self?.resumeIfNeeded()
+        }
+        rateObservation = queuePlayer.observe(\.rate, options: [.new]) { [weak self] _, _ in
+            self?.resumeIfNeeded()
+        }
+
+        // Lightweight safety net: if AVPlayer silently stalls after session switches,
+        // this keeps the loop alive without the old high-frequency timer overhead.
+        let timer = Timer(timeInterval: 0.8, repeats: true) { [weak self] _ in
+            self?.resumeIfNeeded()
         }
         RunLoop.main.add(timer, forMode: .common)
         heartbeatTimer = timer
     }
 
     @objc private func appDidBecomeActive() {
-        forceResume()
+        resumeIfNeeded()
     }
 
     @objc private func handleAudioInterruption(_ notification: Notification) {
-        guard shouldLoop, queuePlayer != nil else { return }
         guard let info = notification.userInfo,
               let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
               let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
-
         if type == .ended {
-            DispatchQueue.main.async { [weak self] in
-                self?.forceResume()
-            }
+            resumeIfNeeded()
         }
     }
 
     @objc private func handleRouteChange() {
-        DispatchQueue.main.async { [weak self] in
-            self?.forceResume()
-        }
+        resumeIfNeeded()
     }
 
-    /// Aggressively resume playback – seeks to unstick a player stuck in
-    /// `.waitingToPlayAtSpecifiedRate` after an audio session change.
-    private func forceResume() {
-        guard shouldLoop, let player = queuePlayer else { return }
-        guard player.rate == 0 || player.timeControlStatus != .playing else { return }
+    private func resumeIfNeeded() {
+        guard shouldLoop else { return }
+        guard UIApplication.shared.applicationState == .active else { return }
+        guard let player = queuePlayer else { return }
 
-        // A seek nudge unsticks the player when it's waiting on the audio session.
+        // After route/session changes AVPlayer may stick in waiting state until nudged.
         if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
             let t = player.currentTime()
             player.seek(to: t, toleranceBefore: .zero, toleranceAfter: .zero)
         }
-        player.play()
+        if player.rate == 0 || player.timeControlStatus != .playing {
+            player.play()
+        }
     }
 
     override func layoutSubviews() {

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -93,9 +93,12 @@ struct InputAreaView: View {
 
     private var activeLevel: CGFloat {
         switch speakModePhase {
-        case .listening: return micLevel
-        case .answering: return speakerLevel
-        default: return 0
+        case .idle: return 0
+        case .connecting, .listening, .processing:
+            return micLevel
+        case .answering:
+            // Keep mic activity visible during assistant playback for barge-in confidence.
+            return max(speakerLevel, micLevel * 0.85)
         }
     }
 
@@ -350,7 +353,7 @@ struct InputAreaView: View {
                 messageCapsule
 
                 // Mute mic button — separate glass circle, speak mode only (hide when typing)
-                if isSpeakModeActive && trimmedInput.isEmpty {
+                if isSpeakModeActive {
                     Button(action: {
                         Haptics.impact(.light)
                         withAnimation(.smooth(duration: 0.3)) {
@@ -369,7 +372,7 @@ struct InputAreaView: View {
                 }
 
                 // Waveform capsule (speak mode only, hide when typing)
-                if isSpeakModeActive && trimmedInput.isEmpty {
+                if isSpeakModeActive {
                     Button(action: {
                         Haptics.impact(.medium)
                         onSpeakToggle()
@@ -395,8 +398,8 @@ struct InputAreaView: View {
                 // Ghost — always mounted so the video never restarts
                 ghostButton
                     .offset(y: 4)
-                    .opacity((!shouldHideGhost || (isSpeakModeActive && trimmedInput.isEmpty)) ? 1 : 0)
-                    .frame(width: (!shouldHideGhost || (isSpeakModeActive && trimmedInput.isEmpty)) ? nil : 0)
+                    .opacity((!shouldHideGhost || isSpeakModeActive) ? 1 : 0)
+                    .frame(width: (!shouldHideGhost || isSpeakModeActive) ? nil : 0)
             }
             .padding(.vertical, 6)
             .padding(.horizontal, isInputFocused.wrappedValue ? 16 : 32)
@@ -522,4 +525,3 @@ struct InputAreaView: View {
         onVoiceModeStop: {}
     )
 }
-

--- a/TalkToMe/Resources
+++ b/TalkToMe/Resources
@@ -1,1 +1,0 @@
-/Users/mac/.config/talktome/Resources

--- a/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
+++ b/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
@@ -53,10 +53,13 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
         self.lastError = nil
         self.isUserSpeaking = false
         self.lastFinalUtterance = nil
-        self.userTranscript = ""
-        self.committedParts = []
-        self.currentInterim = ""
-        self.currentUtteranceFinalParts = []
+        // Don't wipe active transcript state when reconnecting mid-capture.
+        if !self.isRecording {
+            self.userTranscript = ""
+            self.committedParts = []
+            self.currentInterim = ""
+            self.currentUtteranceFinalParts = []
+        }
 
         guard let token = await AuthService.shared.getAccessToken() else {
             self.lastError = "Not authenticated."
@@ -291,8 +294,11 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
             currentInterim = ""
             updatePresentedTranscript()
         } else {
-            currentInterim = trimmed
-            updatePresentedTranscript()
+            // Ignore transient empty interim packets to prevent transcript flicker.
+            if !trimmed.isEmpty {
+                currentInterim = trimmed
+                updatePresentedTranscript()
+            }
             isUserSpeaking = !trimmed.isEmpty
         }
 
@@ -307,7 +313,7 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
             if transcriptAggregation == .perUtterance {
                 committedParts = []
                 currentInterim = ""
-                updatePresentedTranscript()
+                // Keep the last utterance visible until new speech arrives.
             }
         }
     }

--- a/TalkToMe/Services/Backend/SharedAudioEngine.swift
+++ b/TalkToMe/Services/Backend/SharedAudioEngine.swift
@@ -16,6 +16,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     private var isConfigured = false
     private var hasSpeakerLevelTap = false
     private var hasInputTap = false
+    private var isVoiceSessionActive = false
 
     private init() {}
 
@@ -27,19 +28,30 @@ final class SharedAudioEngine: @unchecked Sendable {
         }
     }
 
+    /// Return the app audio session to a non-blocking idle state.
+    /// Safe to call from any thread.
+    func ensureIdleAudioSession() {
+        audioQueue.sync {
+            self.configureIdleAudioSessionOnQueue()
+        }
+    }
+
     /// Must be called on audioQueue.
     private func ensureRunningOnQueue() {
-        if let e = engine, e.isRunning { return }
-
-        // Configure audio session
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetoothHFP])
-            try session.setActive(true, options: [])
-        } catch {
-            print("[SharedAudioEngine] Audio session error: \(error.localizedDescription)")
-            return
+        // Re-acquire voice session only when needed.
+        if !isVoiceSessionActive {
+            let session = AVAudioSession.sharedInstance()
+            do {
+                try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetoothHFP])
+                try session.setActive(true, options: [])
+                isVoiceSessionActive = true
+            } catch {
+                print("[SharedAudioEngine] Audio session error: \(error.localizedDescription)")
+                return
+            }
         }
+
+        if let e = engine, e.isRunning { return }
 
         let eng: AVAudioEngine
         if let existing = engine {
@@ -172,8 +184,6 @@ final class SharedAudioEngine: @unchecked Sendable {
             hasInputTap = false
             playerNode.stop()
             engine?.stop()
-            engine = nil
-            isConfigured = false
             deactivateAudioSessionIfIdleOnQueue()
         }
     }
@@ -190,10 +200,34 @@ final class SharedAudioEngine: @unchecked Sendable {
         guard !hasSpeakerLevelTap else { return }
         guard !playerNode.isPlaying else { return }
 
+        // Deactivate first so iOS can notify interrupted media apps to resume.
+        deactivateVoiceSessionOnQueue()
+
+        // Stop the running engine so hardware is released, but keep the graph warm
+        // to avoid slow mic startup on the next voice interaction.
+        playerNode.stop()
+        engine?.stop()
+    }
+
+    private func deactivateVoiceSessionOnQueue() {
+        let session = AVAudioSession.sharedInstance()
         do {
-            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+            try session.setActive(false, options: [.notifyOthersOnDeactivation])
         } catch {
             print("[SharedAudioEngine] Audio session deactivate error: \(error.localizedDescription)")
         }
+        do {
+            try session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
+        } catch {
+            print("[SharedAudioEngine] Audio session idle category error: \(error.localizedDescription)")
+        }
+        isVoiceSessionActive = false
+    }
+
+    private func configureIdleAudioSessionOnQueue() {
+        guard !hasInputTap else { return }
+        guard !hasSpeakerLevelTap else { return }
+        guard !playerNode.isPlaying else { return }
+        deactivateVoiceSessionOnQueue()
     }
 }

--- a/TalkToMe/TalkToMeApp.swift
+++ b/TalkToMe/TalkToMeApp.swift
@@ -170,6 +170,8 @@ struct TalkToMeApp: App {
                     }
                 }
                 .task {
+                    // Keep decorative media from interrupting other app audio until voice mode is used.
+                    SharedAudioEngine.shared.ensureIdleAudioSession()
                     _ = NetworkMonitor.shared
                     ChatOutboxProcessor.shared.start()
                     // Telegram-like boot: show cached UI immediately while auth restores.


### PR DESCRIPTION
This PR stabilizes iOS voice mode by fixing audio-session handoff, keeping ghost animation running, and improving mic/speak startup timing. It also hardens STT transcript state so waveform/transcript UI no longer disappears mid-capture and keeps speak-mode controls visible while active. Validation: xcodebuild -project TalkToMe.xcodeproj -scheme TalkToMe -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build.