### PR TITLE
Add router include-order clarification comment

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -13,6 +13,7 @@ app = FastAPI()
 # Main FastAPI application instance.
 
 # Keep router wiring centralized so the exposed API surface is easy to audit.
+# Router include order does not affect route matching for these static prefixes.
 app.include_router(aasa_router)
 app.include_router(files_router)
 app.include_router(friends_router)


### PR DESCRIPTION
Adds a small clarifying comment in  near router registration.\n\nThis is a non-functional change intended to improve readability for maintainers reviewing route setup.