### PR TITLE
Add ChatRequest schema comment

### DIFF
--- a/Backend/schemas/chat_models.py
+++ b/Backend/schemas/chat_models.py
@@ -18,6 +18,7 @@ class ChatAttachment(BaseModel):
     content_type: Optional[str] = None
 
 
+# Input payload accepted by the chat endpoint.
 class ChatRequest(BaseModel):
     message: str
     session_id: Optional[UUID] = None


### PR DESCRIPTION
Adds a short clarifying comment above the ChatRequest model in the chat schemas module. This is a documentation-only change and does not alter behavior.