### PR TITLE
Add clarifying comment to FastAPI entrypoint

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -11,6 +11,7 @@ from .subapps.user_profile_router import router as profile_router
 
 app = FastAPI()
 # Main FastAPI application instance.
+# This entrypoint intentionally keeps startup wiring lightweight.
 
 # Register feature routers on the app.
 # Keep router wiring centralized so the exposed API surface is easy to audit.


### PR DESCRIPTION
## Summary
Adds a small clarifying comment in the FastAPI app entrypoint.

## Changes
- Add one non-functional comment in `Backend/app.py` near app initialization.

## Testing
- Not run (comment-only change).