### PR TITLE
Add comment for chat router include

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -22,5 +22,6 @@ app.include_router(friends_router)
 app.include_router(partner_router)
 app.include_router(profile_router)
 app.include_router(notifications_router)
+# Chat endpoints live under the chat router.
 app.include_router(chat_router)
 app.include_router(speech_router)


### PR DESCRIPTION
Adds a small clarifying comment above the chat router registration in Backend/app.py. This is a docs-only change with no runtime behavior changes.