### PR TITLE
chore: document setup idempotency check

### DIFF
--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -50,6 +50,7 @@ fi
 # -------------------------
 # Python venv setup (ROOT)
 # -------------------------
+# Keep setup idempotent so reruns are safe in fresh or partially prepared workspaces.
 if [ ! -d venv ]; then
   echo "🐍 Creating Python virtual environment (root)"
   python3 -m venv venv


### PR DESCRIPTION
Adds a short comment in scripts/conductor-setup.sh explaining that the venv setup is intentionally idempotent for safe reruns. No functional behavior changes.