### PR TITLE
Add signing auditability comment to setup script

### DIFF
--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# Keep repository operations signed (commits/merges/tags) for auditability.
 echo "🔧 Conductor setup (secrets + resources + python venv)"
 
 # -------------------------


### PR DESCRIPTION
Adds a short auditability comment to the Conductor setup script. This is a non-functional documentation-only change. Commit is signed and pushed from branch sgzrov/add-signing-comment.