### PR TITLE
Fix input text scrolling with attachments and speak mode bar expansion

### DIFF
--- a/TalkToMe/Chat/Views/ChatScreenView.swift
+++ b/TalkToMe/Chat/Views/ChatScreenView.swift
@@ -60,7 +60,7 @@ struct ChatScreenView: View {
                 onVoiceModeStart: { chatViewModel.voiceController.startVoiceModePushToTalk() },
                 onVoiceModeStop: { chatViewModel.voiceController.stopVoiceModePushToTalk() }
             )
-            .frame(height: inputAreaHeight, alignment: .bottom)
+            .frame(height: chatViewModel.pendingAttachments.isEmpty ? inputAreaHeight : nil, alignment: .bottom)
             .offset(y: 14)
             .padding(.bottom, isInputFocused.wrappedValue ? 23 : 0)
             .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -328,7 +328,7 @@ struct InputAreaView: View {
                 messageCapsule
 
                 // Mute mic button — separate glass circle, speak mode only (hide when typing)
-                if isSpeakModeActive {
+                if isSpeakModeActive && !shouldHideGhost {
                     Button(action: {
                         Haptics.impact(.light)
                         withAnimation(.smooth(duration: 0.3)) {
@@ -347,7 +347,7 @@ struct InputAreaView: View {
                 }
 
                 // Waveform capsule (speak mode only, hide when typing)
-                if isSpeakModeActive {
+                if isSpeakModeActive && !shouldHideGhost {
                     Button(action: {
                         Haptics.impact(.medium)
                         onSpeakToggle()
@@ -373,8 +373,8 @@ struct InputAreaView: View {
                 // Ghost — always mounted so the video never restarts
                 ghostButton
                     .offset(y: 4)
-                    .opacity((!shouldHideGhost || isSpeakModeActive) ? 1 : 0)
-                    .frame(width: (!shouldHideGhost || isSpeakModeActive) ? nil : 0)
+                    .opacity(!shouldHideGhost ? 1 : 0)
+                    .frame(width: !shouldHideGhost ? nil : 0)
             }
             .padding(.vertical, 6)
             .padding(.horizontal, isInputFocused.wrappedValue ? 16 : 32)


### PR DESCRIPTION
## Summary
- Allow text field to scroll after 5 lines (not 2) when attachments are present by removing the fixed input area height constraint
- Hide speak mode controls (mic mute button, waveform capsule) and ghost button when text/attachments exist so the message capsule expands fully to the right

## Test plan
- Type text with an attachment present and verify scrolling starts after 5 lines
- Activate speak mode, then add text or attachments and verify the bar expands right to cover the ghost

🤖 Generated with Claude Code