### PR TITLE
Preload and recycle ghost video players

### DIFF
--- a/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
+++ b/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
@@ -152,6 +152,19 @@ struct ElevenLabsVoiceSuggestionsView: View {
         "snow": 0.1
     ]
 
+    /// Pre-warm AVPlayers for all ghost videos so they display instantly in the media picker.
+    static func preloadGhostVideos() {
+        for buddy in requiredBuddies {
+            guard Bundle.main.url(forResource: buddy.videoName, withExtension: "mp4") != nil else { continue }
+            TransparentPlayerUIView.preload(
+                videoName: buddy.videoName,
+                extension: "mp4",
+                loop: true,
+                startTime: ghostStartTimes[buddy.videoName] ?? 0
+            )
+        }
+    }
+
     static let ghostImageCache = NSCache<NSString, UIImage>()
 
     private static func normalizedGhostKey(_ rawName: String) -> String {

--- a/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
+++ b/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
@@ -8,6 +8,10 @@ struct TransparentVideoPlayerView: UIViewRepresentable {
     var startTime: Double = 0
 
     func makeUIView(context: Context) -> TransparentPlayerUIView {
+        // Reuse a recycled view that is already playing this video.
+        if let recycled = TransparentPlayerUIView.takeRecycled(for: videoName) {
+            return recycled
+        }
         let view = TransparentPlayerUIView()
         view.configure(videoName: videoName, extension: videoExtension, loop: loop, startTime: startTime)
         return view
@@ -18,7 +22,8 @@ struct TransparentVideoPlayerView: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ uiView: TransparentPlayerUIView, coordinator: ()) {
-        uiView.cleanup()
+        // Don't destroy — recycle so the player keeps running across sheet presentations.
+        TransparentPlayerUIView.recycle(uiView)
     }
 }
 
@@ -31,6 +36,82 @@ final class TransparentPlayerUIView: UIView {
     private var heartbeatTimer: Timer?
     private var shouldLoop = true
     private(set) var currentVideoName: String = ""
+
+    // MARK: - Recycling pool
+
+    private static let recycleLock = NSLock()
+    private static var recycledViews: [String: TransparentPlayerUIView] = [:]
+
+    /// Return a view that is already playing `videoName`, or nil.
+    static func takeRecycled(for videoName: String) -> TransparentPlayerUIView? {
+        recycleLock.lock()
+        defer { recycleLock.unlock() }
+        return recycledViews.removeValue(forKey: videoName)
+    }
+
+    /// Stash a view for reuse instead of destroying it.
+    static func recycle(_ view: TransparentPlayerUIView) {
+        let name = view.currentVideoName
+        guard !name.isEmpty else {
+            view.cleanup()
+            return
+        }
+        // Detach from old superview but keep the player + layer alive.
+        view.removeFromSuperview()
+        recycleLock.lock()
+        recycledViews[name] = view
+        recycleLock.unlock()
+    }
+
+    // MARK: - Preload cache
+
+    private static let preloadLock = NSLock()
+    private static var preloadedPlayers: [String: (player: AVQueuePlayer, looper: AVPlayerLooper?)] = [:]
+
+    /// Pre-build an AVQueuePlayer on a background thread so it's ready instantly
+    /// when `configure` is called later.
+    static func preload(videoName: String, extension ext: String, loop: Bool, startTime: Double = 0) {
+        preloadLock.lock()
+        let exists = preloadedPlayers[videoName] != nil
+        preloadLock.unlock()
+        if exists { return }
+
+        guard let url = Bundle.main.url(forResource: videoName, withExtension: ext) else { return }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let asset = AVURLAsset(url: url)
+            let playerItem = AVPlayerItem(asset: asset)
+            for track in playerItem.tracks where track.assetTrack?.mediaType == .audio {
+                track.isEnabled = false
+            }
+            let player = AVQueuePlayer(playerItem: playerItem)
+            player.volume = 0
+            player.isMuted = true
+            player.automaticallyWaitsToMinimizeStalling = false
+
+            let looper: AVPlayerLooper? = {
+                guard loop else { return nil }
+                if startTime > 0 {
+                    let start = CMTime(seconds: startTime, preferredTimescale: 600)
+                    let range = CMTimeRange(start: start, end: CMTime.positiveInfinity)
+                    return AVPlayerLooper(player: player, templateItem: playerItem, timeRange: range)
+                }
+                return AVPlayerLooper(player: player, templateItem: playerItem)
+            }()
+
+            preloadLock.lock()
+            preloadedPlayers[videoName] = (player: player, looper: looper)
+            preloadLock.unlock()
+        }
+    }
+
+    private static func takePreloaded(for videoName: String) -> (player: AVQueuePlayer, looper: AVPlayerLooper?)? {
+        preloadLock.lock()
+        defer { preloadLock.unlock() }
+        return preloadedPlayers.removeValue(forKey: videoName)
+    }
+
+    // MARK: - Init
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -51,13 +132,19 @@ final class TransparentPlayerUIView: UIView {
         currentVideoName = videoName
         shouldLoop = loop
 
+        // Decorative ghost playback should never claim exclusive audio focus.
+        SharedAudioEngine.shared.ensureIdleAudioSession()
+
+        // Fast path: use a pre-warmed player if available.
+        if let preloaded = Self.takePreloaded(for: videoName) {
+            attachPlayer(preloaded.player, looper: preloaded.looper)
+            return
+        }
+
         guard let url = Bundle.main.url(forResource: videoName, withExtension: ext) else {
             print("TransparentVideoPlayer: Could not find \(videoName).\(ext)")
             return
         }
-
-        // Decorative ghost playback should never claim exclusive audio focus.
-        SharedAudioEngine.shared.ensureIdleAudioSession()
 
         // Build AVPlayer off the main thread to avoid blocking UI.
         let capturedName = videoName
@@ -89,61 +176,67 @@ final class TransparentPlayerUIView: UIView {
                     looper?.disableLooping()
                     return
                 }
-                // Another video was requested while we were loading — discard.
                 guard self.currentVideoName == capturedName else {
                     player.pause()
                     looper?.disableLooping()
                     return
                 }
-
-                self.queuePlayer = player
-                self.playerLooper = looper
-
-                let layer = AVPlayerLayer(player: player)
-                layer.videoGravity = .resizeAspect
-                layer.backgroundColor = UIColor.clear.cgColor
-                layer.pixelBufferAttributes = [
-                    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
-                ]
-                self.layer.addSublayer(layer)
-                layer.frame = self.bounds
-                self.playerLayer = layer
-
-                player.play()
-
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(self.appDidBecomeActive),
-                    name: UIApplication.didBecomeActiveNotification,
-                    object: nil
-                )
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(self.handleAudioInterruption(_:)),
-                    name: AVAudioSession.interruptionNotification,
-                    object: nil
-                )
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(self.handleRouteChange),
-                    name: AVAudioSession.routeChangeNotification,
-                    object: nil
-                )
-
-                self.statusObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] _, _ in
-                    self?.resumeIfNeeded()
-                }
-                self.rateObservation = player.observe(\.rate, options: [.new]) { [weak self] _, _ in
-                    self?.resumeIfNeeded()
-                }
-
-                let timer = Timer(timeInterval: 0.8, repeats: true) { [weak self] _ in
-                    self?.resumeIfNeeded()
-                }
-                RunLoop.main.add(timer, forMode: .common)
-                self.heartbeatTimer = timer
+                self.attachPlayer(player, looper: looper)
             }
         }
+    }
+
+    /// Attach a freshly-built player to this view and start playback.
+    private func attachPlayer(_ player: AVQueuePlayer, looper: AVPlayerLooper?) {
+        self.queuePlayer = player
+        self.playerLooper = looper
+
+        let layer = AVPlayerLayer(player: player)
+        layer.videoGravity = .resizeAspect
+        layer.backgroundColor = UIColor.clear.cgColor
+        layer.pixelBufferAttributes = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ]
+        self.layer.addSublayer(layer)
+        layer.frame = self.bounds
+        self.playerLayer = layer
+
+        player.play()
+        setupObservers(for: player)
+    }
+
+    private func setupObservers(for player: AVQueuePlayer) {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.handleAudioInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.handleRouteChange),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil
+        )
+
+        self.statusObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] _, _ in
+            self?.resumeIfNeeded()
+        }
+        self.rateObservation = player.observe(\.rate, options: [.new]) { [weak self] _, _ in
+            self?.resumeIfNeeded()
+        }
+
+        let timer = Timer(timeInterval: 0.8, repeats: true) { [weak self] _ in
+            self?.resumeIfNeeded()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.heartbeatTimer = timer
     }
 
     @objc private func appDidBecomeActive() {

--- a/TalkToMe/TalkToMeApp.swift
+++ b/TalkToMe/TalkToMeApp.swift
@@ -172,6 +172,8 @@ struct TalkToMeApp: App {
                 .task {
                     // Keep decorative media from interrupting other app audio until voice mode is used.
                     SharedAudioEngine.shared.ensureIdleAudioSession()
+                    // Pre-warm ghost video players so the media picker is instant.
+                    ElevenLabsVoiceSuggestionsView.preloadGhostVideos()
                     _ = NetworkMonitor.shared
                     ChatOutboxProcessor.shared.start()
                     // Telegram-like boot: show cached UI immediately while auth restores.


### PR DESCRIPTION
## Summary
- Preload AVQueuePlayer instances at app startup in background
- Recycle UIView containers across sheet presentations instead of destroying
- Ghost videos display instantly on media picker open (subsequent opens are immediate)

## How it works
The recycling pool keeps video players alive when the media picker sheet closes. On next open, the views are reused with their already-playing content, eliminating render delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)