### PR TITLE
Fix waveform reactivity when mic is muted in speak mode

### DIFF
--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -94,10 +94,10 @@ struct InputAreaView: View {
         switch speakModePhase {
         case .idle: return 0
         case .connecting, .listening, .processing:
-            return micLevel
+            return isSpeakMicMuted ? 0 : micLevel
         case .answering:
             // Keep mic activity visible during assistant playback for barge-in confidence.
-            return max(speakerLevel, micLevel * 0.85)
+            return isSpeakMicMuted ? speakerLevel : max(speakerLevel, micLevel * 0.85)
         }
     }
 

--- a/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
+++ b/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
@@ -370,8 +370,8 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
 
         SharedAudioEngine.shared.installInputTap { [weak self] buffer, _ in
             guard let self else { return }
-            self.updateSpawnLevel(from: buffer)
             guard !self.isPaused else { return }
+            self.updateSpawnLevel(from: buffer)
             self.convertAndSend(buffer: buffer, targetFormat: target)
         }
     }
@@ -483,6 +483,7 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
         let gated = max(0, normalized - noiseFloor) / (1 - noiseFloor)
         let shaped = min(1, sqrt(gated))
         Task { @MainActor in
+            guard !self.isPaused else { return }
             self.spawnLevel = shaped
         }
     }


### PR DESCRIPTION
## Summary
When toggling the mic button during speak mode, the waveform should immediately drop to its base level. Previously, it continued reacting to ambient noise even after muting.

## Changes
- Moved the `isPaused` guard before `updateSpawnLevel` in the input tap to prevent audio processing when paused
- Added a guard in the MainActor task to catch stale updates from the audio thread
- Updated the UI to return level 0 when `isSpeakMicMuted` is true

The waveform now correctly stays flat when the mic is muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)