### PR TITLE
Fix audio/chat lag and music resumption

### DIFF
--- a/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
+++ b/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
@@ -67,7 +67,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         self.finishSent = false
         self.pendingFinish = false
 
-        audioQueue.sync {
+        audioQueue.async {
             self.startedPlayback = false
         }
 

--- a/TalkToMe/Services/Backend/SharedAudioEngine.swift
+++ b/TalkToMe/Services/Backend/SharedAudioEngine.swift
@@ -31,7 +31,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     /// Return the app audio session to a non-blocking idle state.
     /// Safe to call from any thread.
     func ensureIdleAudioSession() {
-        audioQueue.sync {
+        audioQueue.async {
             self.configureIdleAudioSessionOnQueue()
         }
     }
@@ -121,11 +121,9 @@ final class SharedAudioEngine: @unchecked Sendable {
 
     /// Remove the input tap (when STT stops recording).
     func removeInputTap() {
-        audioQueue.sync {
-            engine?.inputNode.removeTap(onBus: 0)
-            hasInputTap = false
-        }
         audioQueue.async {
+            self.engine?.inputNode.removeTap(onBus: 0)
+            self.hasInputTap = false
             self.deactivateAudioSessionIfIdleOnQueue()
         }
     }
@@ -153,38 +151,35 @@ final class SharedAudioEngine: @unchecked Sendable {
 
     /// Remove the speaker level tap.
     func removeSpeakerLevelTap() {
-        audioQueue.sync {
-            guard hasSpeakerLevelTap else { return }
-            engine?.mainMixerNode.removeTap(onBus: 0)
-            hasSpeakerLevelTap = false
-        }
         audioQueue.async {
+            guard self.hasSpeakerLevelTap else { return }
+            self.engine?.mainMixerNode.removeTap(onBus: 0)
+            self.hasSpeakerLevelTap = false
             self.deactivateAudioSessionIfIdleOnQueue()
         }
     }
 
     /// Stop the player node without stopping the engine.
     func stopPlayerNode() {
-        audioQueue.sync {
-            playerNode.stop()
-        }
         audioQueue.async {
+            self.playerNode.stop()
             self.deactivateAudioSessionIfIdleOnQueue()
         }
     }
 
     /// Fully stop the engine and tear down. Called when exiting speak mode.
     func stop() {
-        audioQueue.sync {
-            if hasSpeakerLevelTap {
-                engine?.mainMixerNode.removeTap(onBus: 0)
-                hasSpeakerLevelTap = false
+        audioQueue.async {
+            if self.hasSpeakerLevelTap {
+                self.engine?.mainMixerNode.removeTap(onBus: 0)
+                self.hasSpeakerLevelTap = false
             }
-            engine?.inputNode.removeTap(onBus: 0)
-            hasInputTap = false
-            playerNode.stop()
-            engine?.stop()
-            deactivateAudioSessionIfIdleOnQueue()
+            self.engine?.inputNode.removeTap(onBus: 0)
+            self.hasInputTap = false
+            self.playerNode.stop()
+            self.engine?.stop()
+            // Always deactivate on full stop so background music can resume.
+            self.deactivateVoiceSessionOnQueue()
         }
     }
 

--- a/TalkToMe/Shared/ElevenLabsTTSPlayer.swift
+++ b/TalkToMe/Shared/ElevenLabsTTSPlayer.swift
@@ -2,7 +2,7 @@ import AVFoundation
 import Foundation
 
 @MainActor
-final class ElevenLabsTTSPlayer: ObservableObject {
+final class ElevenLabsTTSPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
     static let shared = ElevenLabsTTSPlayer()
 
     @Published var isSpeaking: Bool = false
@@ -10,12 +10,16 @@ final class ElevenLabsTTSPlayer: ObservableObject {
 
     private var player: AVAudioPlayer?
 
-    private init() {}
+    private override init() {
+        super.init()
+    }
 
     func stop() {
         player?.stop()
+        player?.delegate = nil
         player = nil
         isSpeaking = false
+        deactivateAudioSession()
     }
 
     func speak(_ text: String) {
@@ -31,6 +35,21 @@ final class ElevenLabsTTSPlayer: ObservableObject {
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
         try? session.setActive(true, options: [])
+    }
+
+    private func deactivateAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        try? session.setActive(false, options: [.notifyOthersOnDeactivation])
+        try? session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.player?.delegate = nil
+            self.player = nil
+            self.isSpeaking = false
+            self.deactivateAudioSession()
+        }
     }
 
     private func resolveVoiceId() -> String? {
@@ -61,6 +80,7 @@ final class ElevenLabsTTSPlayer: ObservableObject {
             }
             let p = try AVAudioPlayer(data: data)
             self.player = p
+            p.delegate = self
             p.prepareToPlay()
             isSpeaking = true
             p.play()


### PR DESCRIPTION
## Summary
- Replace synchronous dispatch calls on main thread with async to prevent UI freezes during audio operations
- Fix deadlock in ElevenLabsStreamingTTSService TTS playback teardown where async block calls sync on same serial queue
- Ensure audio session properly deactivates with `.notifyOthersOnDeactivation` so background music resumes after speak mode ends
- Add AVAudioPlayerDelegate to ElevenLabsTTSPlayer for cleanup on natural playback completion

## Issues Resolved
- Chat becomes unresponsive while music is playing
- Excessive lag when stopping speech
- Background music never resumes after speak mode