### PR TITLE
Redesign partner message bubbles with domino ghost-avatar layout

### DIFF
--- a/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
@@ -14,12 +14,11 @@ struct PartnerMessageBlockView: View {
         return friendsViewModel.friends.first(where: { $0.id == senderUserId })
     }
 
-    private var resolvedFirstName: String {
+    private var resolvedName: String {
         let fallbackName = PreferenceKeys.getPartnerDisplayName()
-        let resolvedName = (resolvedFriend?.fullName ?? fallbackName)
+        let name = (resolvedFriend?.fullName ?? fallbackName)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let nameToShow = resolvedName.isEmpty ? "Partner" : resolvedName
-        return nameToShow.split(separator: " ").first.map(String.init) ?? "Partner"
+        return name.isEmpty ? "Partner" : name
     }
 
     private var resolvedAvatarURL: String {
@@ -29,38 +28,62 @@ struct PartnerMessageBlockView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    var body: some View {
-        HStack(alignment: .bottom, spacing: 4) {
-            AvatarCacheManager.shared.cachedAsyncImage(
-                urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
-                placeholder: avatarPlaceholder,
-                fallback: avatarPlaceholder
-            )
-            .frame(width: 28, height: 28)
-            .clipShape(Circle())
+    private var resolvedVoiceName: String {
+        if let name = resolvedFriend?.voiceName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return name
+        }
+        let fallback = (UserDefaults.standard.string(forKey: PreferenceKeys.partnerVoiceName) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !fallback.isEmpty { return fallback }
+        // Default ghost when partner's voice is unknown
+        return "mira"
+    }
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(resolvedFirstName)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.leading, 10)
+    private var ghostImage: UIImage? {
+        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: resolvedVoiceName)
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 6) {
+            // Domino: ghost on left (shifted up), profile pic overlaps from right
+            HStack(alignment: .bottom, spacing: -14) {
+                if let ghostImage {
+                    Image(uiImage: ghostImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 48, height: 48)
+                        .offset(y: 1)
+                }
+
+                AvatarCacheManager.shared.cachedAsyncImage(
+                    urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
+                    placeholder: avatarPlaceholder,
+                    fallback: avatarPlaceholder
+                )
+                .frame(width: 43, height: 43)
+                .clipShape(Circle())
+                .zIndex(1)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(resolvedName)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.teal)
 
                 Text(text.isEmpty ? " " : text)
                     .font(.system(size: 17))
                     .lineSpacing(2)
                     .foregroundColor(.primary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(bubbleColor, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-                    .overlay(alignment: .bottomLeading) {
-                        BubbleTailShape()
-                            .fill(bubbleColor)
-                            .frame(width: 12, height: 8)
-                            .offset(x: -3, y: 1)
-                    }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background {
+                PartnerBubbleShape()
+                    .fill(bubbleColor)
             }
 
-            Spacer(minLength: 40)
+            Spacer(minLength: 0)
         }
         .padding(.bottom, 2)
     }
@@ -71,27 +94,51 @@ struct PartnerMessageBlockView: View {
                 .fill(Color.gray.opacity(0.2))
                 .overlay(
                     Image(systemName: "person.fill")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: 15, weight: .medium))
                         .foregroundColor(.gray)
                 )
         )
     }
 }
 
-private struct BubbleTailShape: Shape {
+private struct PartnerBubbleShape: Shape {
     func path(in rect: CGRect) -> Path {
-        Path { p in
-            p.move(to: CGPoint(x: rect.width, y: 0))
-            p.addCurve(
-                to: CGPoint(x: 0, y: rect.height),
-                control1: CGPoint(x: rect.width, y: rect.height * 0.6),
-                control2: CGPoint(x: rect.width * 0.1, y: rect.height)
+        let cr: CGFloat = 18
+        let tailExtent: CGFloat = 5
+
+        return Path { p in
+            // Start top-left after corner
+            p.move(to: CGPoint(x: cr, y: 0))
+
+            // Top edge
+            p.addLine(to: CGPoint(x: rect.width - cr, y: 0))
+            // Top-right corner
+            p.addArc(center: CGPoint(x: rect.width - cr, y: cr),
+                     radius: cr, startAngle: .degrees(-90), endAngle: .degrees(0), clockwise: false)
+            // Right edge
+            p.addLine(to: CGPoint(x: rect.width, y: rect.height - cr))
+            // Bottom-right corner
+            p.addArc(center: CGPoint(x: rect.width - cr, y: rect.height - cr),
+                     radius: cr, startAngle: .degrees(0), endAngle: .degrees(90), clockwise: false)
+            // Bottom edge to tail area
+            p.addLine(to: CGPoint(x: cr, y: rect.height))
+
+            // Bottom of raindrop: curved outward (control below the line)
+            p.addQuadCurve(
+                to: CGPoint(x: -tailExtent, y: rect.height - 1),
+                control: CGPoint(x: 4, y: rect.height + 3)
             )
-            p.addCurve(
-                to: CGPoint(x: rect.width, y: rect.height * 0.4),
-                control1: CGPoint(x: rect.width * 0.3, y: rect.height * 0.9),
-                control2: CGPoint(x: rect.width * 0.7, y: rect.height * 0.5)
+            // Top of raindrop: slightly curved inward
+            p.addQuadCurve(
+                to: CGPoint(x: 0, y: rect.height - cr * 1.2),
+                control: CGPoint(x: 0, y: rect.height - cr * 0.5)
             )
+
+            // Left edge
+            p.addLine(to: CGPoint(x: 0, y: cr))
+            // Top-left corner
+            p.addArc(center: CGPoint(x: cr, y: cr),
+                     radius: cr, startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false)
         }
     }
 }

--- a/TalkToMe/Friends/Models/FriendSummary.swift
+++ b/TalkToMe/Friends/Models/FriendSummary.swift
@@ -5,12 +5,14 @@ struct FriendSummary: Codable, Hashable, Identifiable {
     let fullName: String
     let authProvider: String
     let avatarURL: String?
+    let voiceName: String?
 
     enum CodingKeys: String, CodingKey {
         case id = "user_id"
         case fullName = "full_name"
         case authProvider = "auth_provider"
         case avatarURL = "avatar_url"
+        case voiceName = "voice_name"
     }
 }
 

--- a/TalkToMe/Friends/ViewModels/FriendsViewModel.swift
+++ b/TalkToMe/Friends/ViewModels/FriendsViewModel.swift
@@ -204,6 +204,9 @@ final class FriendsViewModel: ObservableObject {
         if let url = partner.avatarURL?.trimmingCharacters(in: .whitespacesAndNewlines), !url.isEmpty {
             UserDefaults.standard.set(url, forKey: PreferenceKeys.partnerAvatarURL)
         }
+        if let voice = partner.voiceName?.trimmingCharacters(in: .whitespacesAndNewlines), !voice.isEmpty {
+            UserDefaults.standard.set(voice, forKey: PreferenceKeys.partnerVoiceName)
+        }
         UserDefaults.standard.set(partnerId.uuidString, forKey: PreferenceKeys.partnerUserId)
     }
 

--- a/TalkToMe/Services/Backend/BackendServiceFriends.swift
+++ b/TalkToMe/Services/Backend/BackendServiceFriends.swift
@@ -67,7 +67,7 @@ extension BackendService {
             // Backwards-compat: older backend versions returned `[UUID]`.
             if let legacy = try? jsonDecoder.decode(FriendsListResponseBodyLegacy.self, from: data) {
                 return legacy.friends.map {
-                    FriendSummary(id: $0, fullName: "Friend", authProvider: "Unknown", avatarURL: nil)
+                    FriendSummary(id: $0, fullName: "Friend", authProvider: "Unknown", avatarURL: nil, voiceName: nil)
                 }
             }
             let raw = String(data: data, encoding: .utf8) ?? "<non-utf8>"

--- a/TalkToMe/Shared/PreferenceKeys.swift
+++ b/TalkToMe/Shared/PreferenceKeys.swift
@@ -11,6 +11,7 @@ enum PreferenceKeys {
     static let partnerName = "partner_name"
     static let partnerAvatarURL = "partner_avatar_url"
     static let partnerDisplayName = "partner_display_name"
+    static let partnerVoiceName = "partner_voice_name"
     static let ttsVoiceIdentifier = "tts_voice_identifier"
     static let currentUserId = "current_user_id"
     static let didExplicitSignOut = "did_explicit_sign_out"


### PR DESCRIPTION
## Summary
- Partner messages now display with a domino-style layout: ghost image (48x48) overlapping profile pic (43x43)
- Replaced separate tail shape with unified PartnerBubbleShape combining rounded bubble + raindrop entrance
- Partner's full name now appears inline above message text in teal instead of label above bubble
- Message bubbles expand to full width of message list

## Changes
- Add `voiceName` field to FriendSummary for tracking partner's selected ghost
- Default to Mira ghost when partner's voice is unknown
- Update PartnerMessageBlockView layout and shape rendering
- Store partner voice name in PreferenceKeys for persistence

## Test Plan
- Verify partner messages display with correct ghost-avatar domino layout
- Confirm message bubbles expand properly and raindrop entrance connects smoothly
- Check that partner name displays inline in teal above message content

🤖 Generated with [Claude Code](https://claude.com/claude-code)