### PR TITLE
refactor: simplify partner message UI and widen input area

### DIFF
--- a/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
@@ -28,43 +28,15 @@ struct PartnerMessageBlockView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var resolvedVoiceName: String {
-        if let name = resolvedFriend?.voiceName?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !name.isEmpty {
-            return name
-        }
-        let fallback = (UserDefaults.standard.string(forKey: PreferenceKeys.partnerVoiceName) ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !fallback.isEmpty { return fallback }
-        // Default ghost when partner's voice is unknown
-        return "mira"
-    }
-
-    private var ghostImage: UIImage? {
-        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: resolvedVoiceName)
-    }
-
     var body: some View {
         HStack(alignment: .bottom, spacing: 6) {
-            // Domino: ghost on left (shifted up), profile pic overlaps from right
-            HStack(alignment: .bottom, spacing: -14) {
-                if let ghostImage {
-                    Image(uiImage: ghostImage)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 48, height: 48)
-                        .offset(y: 1)
-                }
-
-                AvatarCacheManager.shared.cachedAsyncImage(
-                    urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
-                    placeholder: avatarPlaceholder,
-                    fallback: avatarPlaceholder
-                )
-                .frame(width: 43, height: 43)
-                .clipShape(Circle())
-                .zIndex(1)
-            }
+            AvatarCacheManager.shared.cachedAsyncImage(
+                urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
+                placeholder: avatarPlaceholder,
+                fallback: avatarPlaceholder
+            )
+            .frame(width: 43, height: 43)
+            .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(resolvedName)

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -381,7 +381,7 @@ struct InputAreaView: View {
                     .frame(width: !shouldHideGhost ? nil : 0)
             }
             .padding(.vertical, 6)
-            .padding(.horizontal, isInputFocused.wrappedValue ? 16 : 40)
+            .padding(.horizontal, isInputFocused.wrappedValue ? 16 : 36)
             .background(
                 GeometryReader { geo in
                     Color.clear.onChange(of: geo.size.width, initial: true) { _, newWidth in


### PR DESCRIPTION
## Summary
- Remove ghost image overlay from partner message blocks, showing only the avatar
- Reduce default input area horizontal padding from 40 to 36 for better message placeholder visibility

## Test plan
- Verify partner messages display only the avatar without ghost overlay
- Check that the input area placeholder text is more visible when unfocused
- Ensure focused state padding (16) remains unchanged