### PR TITLE
Improve buddy picker UI and media selection

### DIFF
--- a/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
+++ b/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
@@ -98,7 +98,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "mira",
             name: "Mira",
-            description: "Cheerful, affectionate with light, bubbly warmth. Soft breathiness, smiling delivery.",
+            description: "Bright, bubbly, and joyful",
             imageName: "mira",
             videoName: "mira",
             aliases: ["mira"]
@@ -106,7 +106,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "pax",
             name: "Pax",
-            description: "Clear, articulate warmth with a patient teacher vibe. Steady cadence, gentle humor.",
+            description: "Calm, clear, and wise",
             imageName: "pax",
             videoName: "pax",
             aliases: ["pax"]
@@ -114,7 +114,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "luma",
             name: "Luma",
-            description: "Warm, compassionate. Soft, airy timbre with gentle breathiness and a reassuring smile.",
+            description: "Soft, warm, and caring",
             imageName: "luma",
             videoName: "luma",
             aliases: ["luma"]
@@ -122,7 +122,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "snow",
             name: "Snow",
-            description: "Soft-spoken and serene with a cozy, calming tone and steady, reflective pacing.",
+            description: "Regal, poised, and grand",
             imageName: "snow",
             videoName: "snow",
             aliases: ["snow"]
@@ -130,7 +130,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "jay",
             name: "Jay",
-            description: "Confident, heroic and encouraging. Upbeat cadence with clear articulation.",
+            description: "Bold, quick, and driven",
             imageName: "jay",
             videoName: "jay",
             aliases: ["jay"]
@@ -138,7 +138,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
         BuddyDefinition(
             key: "hex",
             name: "Hex",
-            description: "Bright, playful and magical. Light airy tone with expressive inflection.",
+            description: "Bookish, arcane, and curious",
             imageName: "hex",
             videoName: "hex",
             aliases: ["hex"]
@@ -214,10 +214,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
 
         return Self.requiredBuddies.map { buddy in
             let matched = buddy.aliases.compactMap { configuredByAlias[$0] }.first
-            let resolvedDescription: String = {
-                let serverDescription = matched?.description.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                return serverDescription.isEmpty ? buddy.description : serverDescription
-            }()
+            let resolvedDescription = buddy.description
             return BuddyOption(
                 definition: buddy,
                 configuredVoiceId: matched?.voice_id,
@@ -378,37 +375,36 @@ struct ElevenLabsVoiceSuggestionsView: View {
     private func voiceCard(_ buddy: BuddyOption) -> some View {
         let isSelected = buddy.definition.key == selectedBuddyKey
 
-        return HStack(spacing: 12) {
+        return HStack(alignment: .center, spacing: 12) {
             ghostPreview(for: buddy.definition)
                 .frame(width: 72, height: 72)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
             VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .top) {
-                    Text(buddy.definition.name)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-
-                    Spacer(minLength: 4)
-
-                    if isSelected {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 18))
-                            .foregroundStyle(.white, .blue)
-                    }
-                }
+                Text(buddy.definition.name)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
 
                 Text(buddy.resolvedDescription)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
-                    .multilineTextAlignment(.leading)
             }
         }
         .padding(10)
         .frame(maxWidth: .infinity, minHeight: 92, alignment: .leading)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(alignment: .topTrailing) {
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.white, .blue)
+                    .padding(8)
+                    .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isSelected)
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .strokeBorder(

--- a/TalkToMe/Chat/Views/Components/MediaPickerPanelView.swift
+++ b/TalkToMe/Chat/Views/Components/MediaPickerPanelView.swift
@@ -110,6 +110,7 @@ final class PhotoThumbnailCache {
 struct MediaPickerPanelView: View {
     @Binding var attachments: [PendingAttachment]
     @Binding var pendingPhotoSelections: [String: PendingAttachment]
+    @Binding var pendingSelectionOrder: [String]
     @Binding var attachmentIdToAssetId: [UUID: String]
     @Environment(\.dismiss) private var dismiss
     @State private var photoPickerItems: [PhotosPickerItem] = []
@@ -209,15 +210,16 @@ struct MediaPickerPanelView: View {
             .ignoresSafeArea()
         }
         .onDisappear {
-            // Add pending selections to attachments when sheet is dismissed
-            for (assetId, attachment) in pendingPhotoSelections {
-                if attachments.count < 12 {
+            // Add pending selections to attachments in selection order
+            for assetId in pendingSelectionOrder {
+                if let attachment = pendingPhotoSelections[assetId], attachments.count < 12 {
                     attachments.append(attachment)
                     attachmentIdToAssetId[attachment.id] = assetId
                 }
             }
             // Clear pending selections after adding
             pendingPhotoSelections.removeAll()
+            pendingSelectionOrder.removeAll()
         }
         .alert("Camera not available", isPresented: $showCameraUnavailableAlert) {
             Button("OK", role: .cancel) {}
@@ -256,7 +258,10 @@ struct MediaPickerPanelView: View {
         if pendingPhotoSelections[assetId] != nil {
             await MainActor.run {
                 Haptics.impact(.light)
-                pendingPhotoSelections.removeValue(forKey: assetId)
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    pendingPhotoSelections.removeValue(forKey: assetId)
+                    pendingSelectionOrder.removeAll { $0 == assetId }
+                }
             }
             return
         }
@@ -265,8 +270,10 @@ struct MediaPickerPanelView: View {
         if let attachmentId = attachmentIdToAssetId.first(where: { $0.value == assetId })?.key {
             await MainActor.run {
                 Haptics.impact(.light)
-                attachments.removeAll { $0.id == attachmentId }
-                attachmentIdToAssetId.removeValue(forKey: attachmentId)
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    attachments.removeAll { $0.id == attachmentId }
+                    attachmentIdToAssetId.removeValue(forKey: attachmentId)
+                }
             }
             return
         }
@@ -302,9 +309,19 @@ struct MediaPickerPanelView: View {
         await MainActor.run {
             if attachments.count + pendingPhotoSelections.count < 12 {
                 Haptics.impact(.light)
-                pendingPhotoSelections[assetId] = attachment
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    pendingPhotoSelections[assetId] = attachment
+                    pendingSelectionOrder.append(assetId)
+                }
             }
         }
+    }
+
+    private func selectionNumber(for assetId: String) -> Int? {
+        if let index = pendingSelectionOrder.firstIndex(of: assetId) {
+            return index + 1
+        }
+        return nil
     }
 
     @ViewBuilder
@@ -334,13 +351,20 @@ struct MediaPickerPanelView: View {
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .fill(Color.black.opacity(0.25))
                         .frame(width: recentThumbSize, height: recentThumbSize)
+                        .transition(.opacity)
 
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(.white, .blue)
-                        .padding(6)
+                    if let number = selectionNumber(for: assetId) {
+                        Text("\(number)")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 24, height: 24)
+                            .background(Circle().fill(Color.blue))
+                            .padding(6)
+                            .transition(.scale.combined(with: .opacity))
+                    }
                 }
             }
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isSelected)
         }
         .buttonStyle(.plain)
         .onAppear {
@@ -537,6 +561,7 @@ private final class RecentPhotosViewModel: ObservableObject {
     MediaPickerPanelView(
         attachments: .constant([]),
         pendingPhotoSelections: .constant([:]),
+        pendingSelectionOrder: .constant([]),
         attachmentIdToAssetId: .constant([:])
     )
         .background(Color.black)

--- a/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
+++ b/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
@@ -51,7 +51,10 @@ final class TransparentPlayerUIView: UIView {
         recycleLock.lock()
         defer { recycleLock.unlock() }
         guard let view = recycledViews.removeValue(forKey: videoName) else { return nil }
-        // Resume playback — the player was paused when recycled.
+        // Restart observers and resume playback.
+        if let player = view.queuePlayer {
+            view.setupObservers(for: player)
+        }
         view.queuePlayer?.play()
         return view
     }
@@ -65,8 +68,9 @@ final class TransparentPlayerUIView: UIView {
         }
         // Detach from old superview but keep the player + layer alive.
         view.removeFromSuperview()
-        // Pause so the player doesn't hold audio session resources
-        // (prevents blocking audio session deactivation / music resumption).
+        // Stop the heartbeat timer and observers so the paused player doesn't get
+        // resumed in the background, draining resources.
+        view.suspendObservers()
         view.queuePlayer?.pause()
         recycleLock.lock()
         recycledViews[name] = view
@@ -305,6 +309,17 @@ final class TransparentPlayerUIView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         playerLayer?.frame = bounds
+    }
+
+    /// Pause monitoring without destroying the player, used when recycling.
+    func suspendObservers() {
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
+        statusObservation?.invalidate()
+        statusObservation = nil
+        rateObservation?.invalidate()
+        rateObservation = nil
+        NotificationCenter.default.removeObserver(self)
     }
 
     func cleanup() {

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -24,6 +24,7 @@ struct InputAreaView: View {
 
     @State private var isMediaPanelVisible: Bool = false
     @State private var pendingPhotoSelections: [String: PendingAttachment] = [:]
+    @State private var pendingSelectionOrder: [String] = []
     @State private var attachmentIdToAssetId: [UUID: String] = [:]
     @State private var inputAreaWidth: CGFloat = 0
     @State private var showMicSlash: Bool = false
@@ -39,9 +40,9 @@ struct InputAreaView: View {
         !(trimmedInput.isEmpty && pendingAttachments.isEmpty)
     }
 
-    /// Hide the ghost when typing, voice recording, or attachments are present.
+    /// Hide the ghost when typing, voice recording, attachments are present, or loading a response.
     private var shouldHideGhost: Bool {
-        !trimmedInput.isEmpty || isVoiceRecording || !pendingAttachments.isEmpty
+        !trimmedInput.isEmpty || isVoiceRecording || !pendingAttachments.isEmpty || (isLoading && !isSpeakModeActive)
     }
 
     /// Approximate text width available inside the capsule when the ghost is visible (collapsed layout).
@@ -200,6 +201,7 @@ struct InputAreaView: View {
                                     withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
                                         if let assetId = attachmentIdToAssetId[att.id] {
                                             pendingPhotoSelections.removeValue(forKey: assetId)
+                                            pendingSelectionOrder.removeAll { $0 == assetId }
                                             attachmentIdToAssetId.removeValue(forKey: att.id)
                                         }
                                         pendingAttachments.removeAll { $0.id == att.id }
@@ -232,7 +234,7 @@ struct InputAreaView: View {
                 if !isVoiceRecording && !hideMicForStop && !isSpeakModeActive {
                     Image(systemName: "mic")
                         .font(.system(size: 19, weight: .semibold))
-                        .foregroundColor(.primary)
+                        .foregroundColor(.secondary)
                         .frame(width: 32, height: 32)
                         .contentShape(Rectangle())
                         .transition(.symbolEffect(.disappear))
@@ -246,7 +248,7 @@ struct InputAreaView: View {
                 if showMicSlash {
                     // Stop button: small square
                     RoundedRectangle(cornerRadius: 3, style: .continuous)
-                        .fill(Color.primary)
+                        .fill(Color.secondary)
                         .frame(width: 12, height: 12)
                         .frame(width: 32, height: 32)
                         .contentShape(Circle())
@@ -279,12 +281,12 @@ struct InputAreaView: View {
                         }
                     }) {
                         Image(systemName: (isLoading && !isSpeakModeActive) ? "stop.fill" : "arrow.up")
-                            .font(.system(size: 19, weight: .semibold))
-                            .foregroundColor((isLoading && !isSpeakModeActive) ? .red : .white)
+                            .font(.system(size: (isLoading && !isSpeakModeActive) ? 13 : 19, weight: .semibold))
+                            .foregroundColor((isLoading && !isSpeakModeActive) ? .primary : .white)
                             .frame(width: 32, height: 32)
                             .background(
                                 RoundedRectangle(cornerRadius: 22, style: .continuous)
-                                    .fill((isLoading && !isSpeakModeActive) ? Color.clear : Color.accentColor)
+                                    .fill(Color.accentColor)
                             )
                     }
                     .buttonStyle(.plain)
@@ -381,7 +383,7 @@ struct InputAreaView: View {
                     .frame(width: !shouldHideGhost ? nil : 0)
             }
             .padding(.vertical, 6)
-            .padding(.horizontal, isInputFocused.wrappedValue ? 16 : 36)
+            .padding(.horizontal, (isInputFocused.wrappedValue || (isLoading && !isSpeakModeActive)) ? 16 : 36)
             .background(
                 GeometryReader { geo in
                     Color.clear.onChange(of: geo.size.width, initial: true) { _, newWidth in
@@ -404,6 +406,7 @@ struct InputAreaView: View {
                 MediaPickerPanelView(
                     attachments: $pendingAttachments,
                     pendingPhotoSelections: $pendingPhotoSelections,
+                    pendingSelectionOrder: $pendingSelectionOrder,
                     attachmentIdToAssetId: $attachmentIdToAssetId
                 )
                 .presentationDetents([.medium])


### PR DESCRIPTION
## Summary
Enhanced the buddy selection picker and photo media experience with better visual hierarchy and refined interactions. Photos now show numbered badges reflecting selection order, and the ghost video resource leak is fixed.

## Changes
- Shortened buddy descriptions to 4 words with personality vibes
- Moved checkmark overlay to prevent card layout issues
- Added numbered photo selection badges (1, 2, 3...)
- Photos insert in selection order, not randomly
- Fixed ghost disappearing: suspend video observers when recycled
- Keep message bar expanded while waiting for response
- Gray out mic and stop icons, keep send button blue
- Show smaller stop icon in send button during loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)