### PR TITLE
Improve buddy message UI and add message regeneration

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -88,6 +88,10 @@ final class ChatStreamingController {
         currentStreamingSessionId == sessionId
     }
 
+    func clearResponseId(for sessionId: UUID) {
+        responseIdBySession.removeValue(forKey: sessionId)
+    }
+
     func handleSessionPresented(_ id: UUID) {
         if let placeholderId = assistantMessageIdBySession[id] {
             currentAssistantMessageId = placeholderId

--- a/TalkToMe/Chat/ViewModels/ChatViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatViewModel.swift
@@ -24,6 +24,7 @@ class ChatViewModel: ObservableObject {
     @Published var isLoadingHistory: Bool = false
     @Published var isAssistantTyping: Bool = false
     @Published var initialJumpToken: Int = 0
+    @Published var regenerationCounts: [String: Int] = [:]
 
     let voiceController = ChatVoiceModeController()
     let streamingController = ChatStreamingController()
@@ -229,6 +230,50 @@ class ChatViewModel: ObservableObject {
             )
             partnerDrafts.markPartnerDraftAsSent(sessionId: sid, messageContent: trimmed)
         } catch { }
+    }
+
+    func regenerateResponse(for assistantMessageId: UUID) {
+        guard !streamingController.isStreaming else { return }
+
+        guard let assistantIndex = messages.firstIndex(where: { $0.id == assistantMessageId }) else { return }
+
+        // Find the preceding user message
+        var userMessageText = ""
+        var userMessageIndex: Int? = nil
+        for i in stride(from: assistantIndex - 1, through: 0, by: -1) {
+            if messages[i].isFromUser {
+                userMessageText = messages[i].segments.compactMap { seg -> String? in
+                    if case .text(let t) = seg { return t }
+                    return nil
+                }.joined()
+                userMessageIndex = i
+                break
+            }
+        }
+
+        let trimmed = userMessageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let userIdx = userMessageIndex else { return }
+
+        Haptics.impact(.medium)
+
+        // Increment regeneration count keyed by user message text
+        regenerationCounts[trimmed, default: 0] += 1
+
+        // Truncate: remove user message and everything after it
+        messages = Array(messages[..<userIdx])
+        chatMessagesVM.updateCacheForCurrentSession(currentMessages: messages)
+
+        // Clear stale response ID so backend doesn't reference deleted context
+        if let sid = sessionId {
+            streamingController.clearResponseId(for: sid)
+        }
+
+        // Re-send the user message (sendMessage recreates it + streams new response)
+        streamingController.sendMessage(overrideText: trimmed)
+    }
+
+    func regenerationCount(forUserMessageText text: String) -> Int {
+        regenerationCounts[text.trimmingCharacters(in: .whitespacesAndNewlines)] ?? 0
     }
 
     func presentSession(_ id: UUID) async {

--- a/TalkToMe/Chat/Views/Components/AssistantMessageActionsView.swift
+++ b/TalkToMe/Chat/Views/Components/AssistantMessageActionsView.swift
@@ -2,40 +2,49 @@ import SwiftUI
 
 struct AssistantMessageActionsView: View {
     let messageText: String
+    let regenerationCount: Int
     let onRegenerate: (() -> Void)?
-    
-    @State private var showCopyCheck: Bool = false
+
     @State private var feedbackGiven: FeedbackType? = nil
-    
+
     private enum FeedbackType {
         case positive
         case negative
     }
-    
+
+    init(
+        messageText: String,
+        regenerationCount: Int = 0,
+        onRegenerate: (() -> Void)? = nil
+    ) {
+        self.messageText = messageText
+        self.regenerationCount = regenerationCount
+        self.onRegenerate = onRegenerate
+    }
+
     var body: some View {
-        HStack(spacing: 16) {
-            // Copy button
-            Button(action: copyToClipboard) {
-                Image(systemName: showCopyCheck ? "checkmark" : "doc.on.doc")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(showCopyCheck ? .green : .secondary)
-            }
-            .buttonStyle(.plain)
-            .animation(.easeInOut(duration: 0.15), value: showCopyCheck)
-            
+        HStack(spacing: 12) {
             // Regenerate button
             if let onRegenerate {
                 Button(action: {
                     Haptics.impact(.light)
                     onRegenerate()
                 }) {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.secondary)
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.secondary)
+
+                        if regenerationCount > 0 {
+                            Text("x\(regenerationCount)")
+                                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                                .foregroundColor(.secondary)
+                        }
+                    }
                 }
                 .buttonStyle(.plain)
             }
-            
+
             // Thumbs up
             Button(action: { giveFeedback(.positive) }) {
                 Image(systemName: feedbackGiven == .positive ? "hand.thumbsup.fill" : "hand.thumbsup")
@@ -44,7 +53,7 @@ struct AssistantMessageActionsView: View {
             }
             .buttonStyle(.plain)
             .disabled(feedbackGiven != nil)
-            
+
             // Thumbs down
             Button(action: { giveFeedback(.negative) }) {
                 Image(systemName: feedbackGiven == .negative ? "hand.thumbsdown.fill" : "hand.thumbsdown")
@@ -53,23 +62,13 @@ struct AssistantMessageActionsView: View {
             }
             .buttonStyle(.plain)
             .disabled(feedbackGiven != nil)
-            
+
             Spacer()
         }
         .padding(.top, 8)
         .padding(.leading, 4)
     }
-    
-    private func copyToClipboard() {
-        guard !showCopyCheck else { return }
-        UIPasteboard.general.string = messageText
-        Haptics.impact(.light)
-        showCopyCheck = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            showCopyCheck = false
-        }
-    }
-    
+
     private func giveFeedback(_ type: FeedbackType) {
         Haptics.impact(.light)
         withAnimation(.easeInOut(duration: 0.2)) {
@@ -83,9 +82,16 @@ struct AssistantMessageActionsView: View {
     VStack(spacing: 20) {
         AssistantMessageActionsView(
             messageText: "Hello! This is a test message.",
+            regenerationCount: 0,
             onRegenerate: { print("Regenerate tapped") }
         )
-        
+
+        AssistantMessageActionsView(
+            messageText: "Regenerated message.",
+            regenerationCount: 2,
+            onRegenerate: { print("Regenerate tapped") }
+        )
+
         AssistantMessageActionsView(
             messageText: "Message without regenerate option.",
             onRegenerate: nil

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -162,7 +162,7 @@ struct MessageBubbleView: View {
     let message: ChatMessage
 
     var onSendToPartner: ((String) -> Void)? = nil
-    var onRegenerate: (() -> Void)? = nil
+    var onRegenerate: ((UUID) -> Void)? = nil
 
     var sendAnimationNamespace: Namespace.ID? = nil
     var outgoingAnimatingMessageId: UUID? = nil
@@ -271,9 +271,22 @@ struct MessageBubbleView: View {
                         
                         // Action buttons for assistant messages
                         if shouldShowAssistantActions {
+                            let precedingUserText: String = {
+                                guard let idx = chatViewModel.messages.firstIndex(where: { $0.id == message.id }) else { return "" }
+                                for i in stride(from: idx - 1, through: 0, by: -1) {
+                                    if chatViewModel.messages[i].isFromUser {
+                                        return chatViewModel.messages[i].segments.compactMap { seg -> String? in
+                                            if case .text(let t) = seg { return t }
+                                            return nil
+                                        }.joined()
+                                    }
+                                }
+                                return ""
+                            }()
                             AssistantMessageActionsView(
                                 messageText: plainText(from: message.segments),
-                                onRegenerate: onRegenerate
+                                regenerationCount: chatViewModel.regenerationCount(forUserMessageText: precedingUserText),
+                                onRegenerate: onRegenerate != nil ? { onRegenerate?(message.id) } : nil
                             )
                             .transition(.opacity.animation(.easeIn(duration: 0.2)))
                         }

--- a/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
@@ -5,6 +5,7 @@ struct PartnerDraftBlockView: View {
     enum Action { case send(String) }
 
     @EnvironmentObject private var friendsViewModel: FriendsViewModel
+    @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var buddyName: String = ""
 
     @State private var text: String
     @State private var isConfirmingNormalSend: Bool = false
@@ -31,33 +32,75 @@ struct PartnerDraftBlockView: View {
         self.onAction = onAction
     }
 
+    private var resolvedBuddyName: String {
+        let name = buddyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Your buddy" : name
+    }
+
+    private var buddyImage: UIImage? {
+        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddyName)
+    }
+
+    private var recipientFirstName: String {
+        guard let recipientUserId else { return "Friend" }
+        let friend = friendsViewModel.friends.first(where: { $0.id == recipientUserId })
+        let fullName = (friend?.fullName ?? "Friend").trimmingCharacters(in: .whitespacesAndNewlines)
+        return fullName.split(separator: " ").first.map(String.init) ?? "Friend"
+    }
+
+    private var alreadySent: Bool {
+        isLinked && (isSent || showSentLocally)
+    }
+
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("Message")
-                .font(.footnote)
-                .foregroundColor(Color.secondary)
-                .offset(y: -4)
+        VStack(alignment: .leading, spacing: 12) {
+            // Buddy header
+            HStack(spacing: 8) {
+                if let uiImage = buddyImage {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 28, height: 28)
+                        .clipShape(Circle())
+                } else {
+                    Circle()
+                        .fill(Color(.systemGray5))
+                        .frame(width: 28, height: 28)
+                        .overlay(
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundColor(.secondary)
+                        )
+                }
 
-            Divider()
-                .padding(.horizontal, -12)
-                .offset(y: -4)
+                HStack(spacing: 4) {
+                    Text(resolvedBuddyName)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.primary)
 
-            // NOTE:
-            // We used to measure the content height via GeometryReader + PreferenceKey and then
-            // drive a TextEditor frame from that measurement. That pattern can create SwiftUI
-            // AttributeGraph cycles (layout -> preference -> state write -> layout ...).
-            //
-            // This is a read-only block, so a plain Text view (with selection enabled) is simpler,
-            // faster, and avoids any layout feedback loops.
+                    Text("drafted this")
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "sparkles")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary.opacity(0.6))
+            }
+
+            // Message body
             Text(text.isEmpty ? " " : text)
                 .font(.callout)
                 .foregroundColor(.primary)
                 .multilineTextAlignment(.leading)
+                .lineSpacing(2)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
-                .padding(.vertical, 8)
                 .padding(.horizontal, 4)
 
+            // Send button
             HStack {
                 if isConfirmingNormalSend {
                     Button(action: {
@@ -67,8 +110,8 @@ struct PartnerDraftBlockView: View {
                         }
                     }) {
                         Text("Cancel")
-                            .font(.subheadline)
-                            .foregroundColor(Color.secondary)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
                     .transition(.scale.combined(with: .opacity))
@@ -76,79 +119,17 @@ struct PartnerDraftBlockView: View {
 
                 Spacer()
 
-                HStack(spacing: 8) {
-                    Button(action: {
-                        guard !(isLinked && (isSent || showSentLocally)) else { return }
-                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-
-                        Haptics.impact(.light)
-
-                        if isConfirmingNormalSend {
-                            if isLinked {
-                                withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                                    showSentLocally = true
-                                    isConfirmingNormalSend = false
-                                }
-                                onAction(.send(trimmed))
-                            } else {
-                                withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                                    isConfirmingNormalSend = false
-                                }
-                                onAction(.send(trimmed))
-                            }
-                        } else {
-                            withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                                isConfirmingNormalSend = true
-                            }
-                        }
-                    }) {
-                        ZStack {
-                            if isLinked && (isSent || showSentLocally) {
-                                HStack(spacing: 6) {
-                                    let resolvedFriend: FriendSummary? = {
-                                        guard let recipientUserId else { return nil }
-                                        return friendsViewModel.friends.first(where: { $0.id == recipientUserId })
-                                    }()
-                                    let fullName = (resolvedFriend?.fullName ?? "Friend").trimmingCharacters(in: .whitespacesAndNewlines)
-                                    let firstName = fullName.split(separator: " ").first.map(String.init) ?? "Friend"
-                                    Text("Sent to \(firstName)")
-                                        .font(.subheadline)
-                                        .foregroundColor(Color.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundColor(Color.green)
-                                }
-                                .transition(.scale.combined(with: .opacity))
-                            } else if isConfirmingNormalSend {
-                                Text("Confirm sending")
-                                    .font(.subheadline)
-                                    .foregroundColor(Color.accentColor)
-                                    .transition(.scale.combined(with: .opacity))
-                            } else {
-                                HStack(spacing: 6) {
-                                    Text("Send now")
-                                        .font(.subheadline)
-                                        .foregroundColor(Color.accentColor)
-                                    Image(systemName: "arrow.turn.up.right")
-                                        .foregroundColor(Color.accentColor)
-                                }
-                                .transition(.scale.combined(with: .opacity))
-                            }
-                        }
-                    }
-                    .disabled(isLinked && (isSent || showSentLocally))
+                Button(action: handleSendTap) {
+                    sendButtonContent
                 }
+                .buttonStyle(.plain)
+                .disabled(alreadySent)
             }
         }
-        .padding(12)
+        .padding(14)
         .background(
-            RoundedRectangle(cornerRadius: 16)
-                .strokeBorder(Color(.separator), lineWidth: 1)
-                .background(
-                    RoundedRectangle(cornerRadius: 16).fill(Color(.systemBackground))
-                )
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
         )
         .onAppear {
             isConfirmingNormalSend = false
@@ -164,6 +145,80 @@ struct PartnerDraftBlockView: View {
             if isSent { showSentLocally = false }
         }
     }
+
+    @ViewBuilder
+    private var sendButtonContent: some View {
+        ZStack {
+            if alreadySent {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text("Sent")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.green)
+                )
+                .transition(.scale.combined(with: .opacity))
+            } else if isConfirmingNormalSend {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text("Confirm")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.accentColor.opacity(0.85))
+                )
+                .transition(.scale.combined(with: .opacity))
+            } else {
+                HStack(spacing: 6) {
+                    Text("Send to \(recipientFirstName)")
+                        .font(.system(size: 14, weight: .semibold))
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.accentColor)
+                )
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+    }
+
+    private func handleSendTap() {
+        guard !alreadySent else { return }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        Haptics.impact(.light)
+
+        if isConfirmingNormalSend {
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                if isLinked {
+                    showSentLocally = true
+                }
+                isConfirmingNormalSend = false
+            }
+            onAction(.send(trimmed))
+        } else {
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                isConfirmingNormalSend = true
+            }
+        }
+    }
 }
 
 #Preview {
@@ -174,4 +229,3 @@ struct PartnerDraftBlockView: View {
     ) { _ in }
         .padding()
 }
-

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -59,6 +59,9 @@ struct MessagesListView: View {
                         onSendToPartner: { text in
                             NotificationCenter.default.post(name: .sendPartnerMessageFromBubble, object: nil, userInfo: ["content": text])
                         },
+                        onRegenerate: { messageId in
+                            chatViewModel.regenerateResponse(for: messageId)
+                        },
                         sendAnimationNamespace: sendAnimationNamespace,
                         outgoingAnimatingMessageId: outgoingAnimatingMessageId
                     )


### PR DESCRIPTION
## Summary

- Redesigned PartnerDraftBlockView with buddy avatar header, "drafted this" label, and improved send button UX
- Added message regeneration: when repeat is clicked, all messages from that point onwards are deleted and the response is re-generated with a typing indicator
- Track regeneration count (xN) and display next to regenerate button
- Removed copy button from assistant message actions

## Test plan

- Send and receive messages in chat
- Click regenerate button on assistant messages and verify prior messages are deleted
- Verify regeneration count increments and displays correctly
- Test send to partner flow with new UI design

🤖 Generated with [Claude Code](https://claude.com/claude-code)