### PR TITLE
Fix response streaming and thinking indicator UX

### DIFF
--- a/Backend/crud/chat/chat_crud.py
+++ b/Backend/crud/chat/chat_crud.py
@@ -187,9 +187,10 @@ async def count_user_messages(*, session_id: uuid.UUID) -> int:
     return await run_in_threadpool(_count)
 
 
-async def delete_messages_after(*, user_id: uuid.UUID, session_id: uuid.UUID, after_message_id: uuid.UUID) -> int:
+async def delete_messages_after(*, user_id: uuid.UUID, session_id: uuid.UUID, after_message_id: uuid.UUID, include_anchor: bool = False) -> int:
     """Delete all messages in a session that were created after the given message.
-    The anchor message itself is preserved."""
+    When *include_anchor* is True the anchor message itself is also deleted
+    (useful for regeneration where the user message is re-created)."""
 
     def _delete():
         db = SessionLocal()
@@ -204,20 +205,91 @@ async def delete_messages_after(*, user_id: uuid.UUID, session_id: uuid.UUID, af
 
             from sqlalchemy import and_, or_
 
-            condition = and_(
-                UserChatMessage.session_id == session_id,
-                or_(
-                    UserChatMessage.created_at > anchor_ts,
-                    and_(
+            if include_anchor:
+                condition = and_(
+                    UserChatMessage.session_id == session_id,
+                    or_(
+                        UserChatMessage.created_at > anchor_ts,
                         UserChatMessage.created_at == anchor_ts,
-                        UserChatMessage.id != after_message_id,
                     ),
-                ),
-            )
+                )
+            else:
+                condition = and_(
+                    UserChatMessage.session_id == session_id,
+                    or_(
+                        UserChatMessage.created_at > anchor_ts,
+                        and_(
+                            UserChatMessage.created_at == anchor_ts,
+                            UserChatMessage.id != after_message_id,
+                        ),
+                    ),
+                )
             count = len(db.execute(select(UserChatMessage.id).where(condition)).all())
             db.execute(delete(UserChatMessage).where(condition))
             db.commit()
             return count
+        finally:
+            db.close()
+
+    return await run_in_threadpool(_delete)
+
+
+async def delete_partner_message(
+    *,
+    sender_user_id: uuid.UUID,
+    sender_session_id: uuid.UUID,
+    message_text: str,
+) -> bool:
+    """Delete a partner message from the recipient's linked session.
+    Identifies the message by matching the JSON payload content."""
+    import json
+
+    def _delete():
+        db = SessionLocal()
+        try:
+            sender_session = (
+                db.execute(
+                    select(UserChatSession).where(
+                        UserChatSession.id == sender_session_id,
+                        UserChatSession.user_id == sender_user_id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if not sender_session or not sender_session.linked_session_id:
+                return False
+
+            recipient_session_id = sender_session.linked_session_id
+            expected_payload = json.dumps(
+                {
+                    "_talktome": {
+                        "type": "partner_received",
+                        "text": message_text,
+                        "sender_user_id": str(sender_user_id),
+                    }
+                }
+            )
+
+            msg = (
+                db.execute(
+                    select(UserChatMessage).where(
+                        UserChatMessage.session_id == recipient_session_id,
+                        UserChatMessage.role == "assistant",
+                        UserChatMessage.content == expected_payload,
+                    )
+                    .order_by(UserChatMessage.created_at.desc())
+                    .limit(1)
+                )
+                .scalars()
+                .first()
+            )
+            if not msg:
+                return False
+
+            db.delete(msg)
+            db.commit()
+            return True
         finally:
             db.close()
 

--- a/Backend/schemas/chat_models.py
+++ b/Backend/schemas/chat_models.py
@@ -29,6 +29,7 @@ class ChatRequest(BaseModel):
     friend_user_id: Optional[UUID] = None
     ephemeral: bool = False
     voice_agent: Optional[str] = None
+    ghost_name: Optional[str] = None
 
 
 class ChatResponse(BaseModel):

--- a/Backend/services/chat_service.py
+++ b/Backend/services/chat_service.py
@@ -70,13 +70,13 @@ class ChatService:
             previous_response_id=previous_response_id,
         )
 
-    def stream_response(self, *, messages: List[dict], previous_response_id: Optional[str] = None):
+    def stream_response(self, *, messages: List[dict], previous_response_id: Optional[str] = None, reasoning_effort: str = "medium"):
         return self.client.responses.stream(
             model=self.vision_model if any(isinstance(m.get("content"), list) for m in messages) else self.model,
             input=messages,
             store=True,
             text={"verbosity": "medium"},
-            reasoning={"effort": "medium"},
+            reasoning={"effort": reasoning_effort, "summary": "auto"},
             previous_response_id=previous_response_id,
         )
 
@@ -263,4 +263,3 @@ class VoiceChatService:
                 yield GeminiStreamEvent(type="response.error", error=str(e))
 
         yield event_generator()
-

--- a/Backend/subapps/chat_router.py
+++ b/Backend/subapps/chat_router.py
@@ -60,6 +60,21 @@ voice_agent_prompts = VoiceAgentPromptLibrary()
 RAG_TOP_K = int(os.getenv("RAG_TOP_K", "5") or "5")
 RAG_MAX_CHARS_PER_CHUNK = int(os.getenv("RAG_MAX_CHARS_PER_CHUNK", "1200") or "1200")
 
+_HIGH_EFFORT_PATTERNS = re.compile(
+    r"(explain|analyze|compar|why\b|how does|what causes|step.?by.?step|in detail|pros? and cons|trade.?offs?|differences? between)",
+    re.IGNORECASE,
+)
+
+def _classify_reasoning_effort(message: str) -> str:
+    """Choose reasoning effort based on message complexity."""
+    text = (message or "").strip()
+    length = len(text)
+    if length < 30:
+        return "low"
+    if length > 300 or _HIGH_EFFORT_PATTERNS.search(text):
+        return "high"
+    return "medium"
+
 
 def _format_rag_context(rows: list[dict]) -> Optional[str]:
     """
@@ -428,6 +443,7 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                 sess_payload = json.dumps({"session_id": str(session_uuid)})
                 yield f"event: session\ndata: {sess_payload}\n\n".encode()
 
+            ghost_name = (chat_request.ghost_name or "").strip() or None
             full_text_parts = []
             segments_list = []
             current_text_segment = ""
@@ -526,8 +542,46 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                 # For high concurrency, frequent heartbeats add up quickly.
                 heartbeat_interval = 5.0
 
+                received_event_types: set[str] = set()
+                received_text_deltas = 0
+                received_reasoning_summary_deltas = 0
+                received_reasoning_summary_chars = 0
+                received_reasoning_summary_done = 0
+
+                def _reset_stream_debug_counters():
+                    nonlocal received_event_types
+                    nonlocal received_text_deltas
+                    nonlocal received_reasoning_summary_deltas
+                    nonlocal received_reasoning_summary_chars
+                    nonlocal received_reasoning_summary_done
+                    received_event_types = set()
+                    received_text_deltas = 0
+                    received_reasoning_summary_deltas = 0
+                    received_reasoning_summary_chars = 0
+                    received_reasoning_summary_done = 0
+
+                def _log_stream_debug_counters(label: str):
+                    emitted = "yes" if received_reasoning_summary_deltas > 0 else "no"
+                    print(
+                        "[SSE] stream_debug"
+                        f" label={label}"
+                        f" reasoning_summary_emitted={emitted}"
+                        f" reasoning_summary_delta_count={received_reasoning_summary_deltas}"
+                        f" reasoning_summary_char_count={received_reasoning_summary_chars}"
+                        f" reasoning_summary_done_events={received_reasoning_summary_done}"
+                        f" text_delta_count={received_text_deltas}"
+                        f" event_types={sorted(received_event_types)}"
+                    )
+
                 async def _consume_stream(stream):
-                    nonlocal buffer, in_partner, current_text_segment
+                    nonlocal buffer
+                    nonlocal in_partner
+                    nonlocal current_text_segment
+                    nonlocal received_text_deltas
+                    nonlocal received_event_types
+                    nonlocal received_reasoning_summary_deltas
+                    nonlocal received_reasoning_summary_chars
+                    nonlocal received_reasoning_summary_done
                     aiter = stream.__aiter__()
                     while True:
                         try:
@@ -552,10 +606,12 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                         except StopAsyncIteration:
                             break
                         except Exception as e:
+                            print(f"[SSE] stream iteration error: {e}")
                             yield f"event: error\ndata: {json.dumps(str(e))}\n\n".encode()
                             break
 
                         etype = getattr(event, "type", "")
+                        received_event_types.add(etype)
 
                         if etype == "response.created":
                             rid = None
@@ -572,14 +628,50 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                                 err_obj = getattr(event, "error", None)
                                 if err_obj is not None:
                                     err_msg = str(err_obj)
+                            print(f"[SSE] OpenAI response.error: {err_msg}")
                             yield f"event: error\ndata: {json.dumps(err_msg)}\n\n".encode()
                             break
 
                         if etype == "response.completed":
+                            with suppress(Exception):
+                                resp = getattr(event, "response", None)
+                                status = getattr(resp, "status", None)
+                                if status and status != "completed":
+                                    print(f"[SSE] response.completed with status={status}")
+                                rid = getattr(resp, "id", None)
+                                print(
+                                    "[SSE] response.completed"
+                                    f" response_id={rid}"
+                                    f" reasoning_summary_emitted={'yes' if received_reasoning_summary_deltas > 0 else 'no'}"
+                                    f" reasoning_summary_delta_count={received_reasoning_summary_deltas}"
+                                    f" reasoning_summary_char_count={received_reasoning_summary_chars}"
+                                    f" reasoning_summary_done_events={received_reasoning_summary_done}"
+                                    f" text_delta_count={received_text_deltas}"
+                                )
+                                # Log output item types when no text was produced
+                                if received_text_deltas == 0:
+                                    output_items = getattr(resp, "output", []) or []
+                                    item_types = [getattr(item, "type", "?") for item in output_items]
+                                    print(f"[SSE] response.completed with 0 text deltas. output_types={item_types} event_types={sorted(received_event_types)}")
                             break
+
+                        if etype == "response.reasoning_summary_text.delta":
+                            delta = getattr(event, "delta", "") or ""
+                            if delta:
+                                received_reasoning_summary_deltas += 1
+                                received_reasoning_summary_chars += len(delta)
+                                yield f"event: thinking\ndata: {json.dumps(delta)}\n\n".encode()
+                            continue
+
+                        if etype == "response.reasoning_summary_text.done":
+                            received_reasoning_summary_done += 1
+                            yield b"event: thinking_done\ndata: {}\n\n"
+                            continue
 
                         if etype != "response.output_text.delta":
                             continue
+
+                        received_text_deltas += 1
 
                         delta = getattr(event, "delta", "") or ""
                         if not isinstance(delta, str):
@@ -629,28 +721,40 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                                 if current_text_segment:
                                     segments_list.append({"type": "text", "content": current_text_segment})
                                     current_text_segment = ""
-                                segments_list.append({"type": "partner_draft", "text": content})
+                                partner_seg = {"type": "partner_draft", "text": content}
+                                if ghost_name:
+                                    partner_seg["ghost_name"] = ghost_name
+                                segments_list.append(partner_seg)
 
                                 buffer = buffer[close_idx + len(end_marker) :]
                                 in_partner = False
                                 continue
 
                 # Use Gemini for voice-agent / ephemeral mode, OpenAI otherwise.
+                reasoning_effort = _classify_reasoning_effort(chat_request.message)
+                print(f"[SSE] reasoning_effort={reasoning_effort} for message ({len((chat_request.message or '').strip())} chars)")
                 if use_gemini:
+                    _reset_stream_debug_counters()
                     async with voice_chat_service.stream_response(
                         messages=input_messages,
                         previous_response_id=None,  # Gemini doesn't support response chaining
                     ) as stream:
                         async for chunk in _consume_stream(stream):
                             yield chunk
+                    _log_stream_debug_counters("gemini_primary")
                 else:
                     try:
-                        async with chat_service.stream_response(
-                            messages=input_messages,
-                            previous_response_id=chat_request.previous_response_id,
-                        ) as stream:
-                            async for chunk in _consume_stream(stream):
-                                yield chunk
+                        _reset_stream_debug_counters()
+                        try:
+                            async with chat_service.stream_response(
+                                messages=input_messages,
+                                previous_response_id=chat_request.previous_response_id,
+                                reasoning_effort=reasoning_effort,
+                            ) as stream:
+                                async for chunk in _consume_stream(stream):
+                                    yield chunk
+                        finally:
+                            _log_stream_debug_counters("openai_primary")
                     except Exception as e:
                         # If OpenAI rejects `previous_response_id`, retry once without it.
                         msg = str(e)
@@ -661,9 +765,13 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                             buffer = ""
                             in_partner = False
                             current_text_segment = ""
-                            async with chat_service.stream_response(messages=input_messages, previous_response_id=None) as stream:
-                                async for chunk in _consume_stream(stream):
-                                    yield chunk
+                            _reset_stream_debug_counters()
+                            try:
+                                async with chat_service.stream_response(messages=input_messages, previous_response_id=None) as stream:
+                                    async for chunk in _consume_stream(stream):
+                                        yield chunk
+                            finally:
+                                _log_stream_debug_counters("openai_prev_id_retry")
                         else:
                             raise
 
@@ -677,10 +785,46 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                     segments_list.append({"type": "text", "content": current_text_segment})
                     current_text_segment = ""
 
+                # If the AI returned an empty response, retry with reduced reasoning effort
+                # and without previous_response_id. gpt-5.2 sometimes spends its entire
+                # budget on reasoning and produces zero text output.
+                if (
+                    not full_text_parts
+                    and not segments_list
+                    and not in_partner
+                    and not use_gemini
+                ):
+                    prev_id = chat_request.previous_response_id
+                    print(f"[SSE] Empty response (prev_id={'yes' if prev_id else 'no'}), retrying with reasoning=low for session {session_uuid}")
+                    buffer = ""
+                    in_partner = False
+                    current_text_segment = ""
+                    _reset_stream_debug_counters()
+                    try:
+                        async with chat_service.stream_response(
+                            messages=input_messages,
+                            previous_response_id=None,
+                            reasoning_effort="low",
+                        ) as stream:
+                            async for chunk in _consume_stream(stream):
+                                yield chunk
+                    finally:
+                        _log_stream_debug_counters("openai_empty_output_retry_low")
+                    if buffer:
+                        full_text_parts.append(buffer)
+                        yield f"event: token\ndata: {json.dumps(buffer)}\n\n".encode()
+                        current_text_segment += buffer
+                        buffer = ""
+                    if current_text_segment:
+                        segments_list.append({"type": "text", "content": current_text_segment})
+                        current_text_segment = ""
+
                 final_text = "".join(full_text_parts)
                 state["final_text"] = final_text or ""
                 if segments_list:
                     state["segments"] = segments_list
+                elif not final_text:
+                    print(f"[SSE] WARNING: No output produced for session {session_uuid}")
 
                 yield b"event: done\ndata: {}\n\n"
             except Exception as e:
@@ -809,7 +953,12 @@ async def delete_session_route(session_id: uuid.UUID, current_user: dict = Depen
 
 
 @router.delete("/sessions/{session_id}/messages/after/{message_id}")
-async def delete_messages_after_route(session_id: uuid.UUID, message_id: uuid.UUID, current_user: dict = Depends(get_current_user)):
+async def delete_messages_after_route(
+    session_id: uuid.UUID,
+    message_id: uuid.UUID,
+    include_anchor: bool = False,
+    current_user: dict = Depends(get_current_user),
+):
     try:
         user_uuid = uuid.UUID(current_user.get("sub"))
     except Exception:
@@ -817,11 +966,11 @@ async def delete_messages_after_route(session_id: uuid.UUID, message_id: uuid.UU
 
     try:
         await assert_session_owned_by_user(user_id=user_uuid, session_id=session_id)
-        deleted = await delete_messages_after(user_id=user_uuid, session_id=session_id, after_message_id=message_id)
+        deleted = await delete_messages_after(
+            user_id=user_uuid, session_id=session_id, after_message_id=message_id, include_anchor=include_anchor,
+        )
         return {"success": True, "deleted_count": deleted}
     except PermissionError:
         raise HTTPException(status_code=403, detail="Forbidden: invalid session")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-
-

--- a/Backend/subapps/partner_router.py
+++ b/Backend/subapps/partner_router.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from Backend.auth import get_current_user
-from Backend.crud.chat.chat_crud import save_message, update_session_last_message
+from Backend.crud.chat.chat_crud import delete_partner_message, save_message, update_session_last_message
 from Backend.crud.chat.chat_session_crud import (
     ensure_linked_session_for_friendship,
     get_session_by_id,
@@ -152,4 +152,35 @@ async def send_message(request: SendPartnerMessageRequest, current_user: dict = 
         pass
 
     return SendPartnerMessageResponse(success=True, recipient_session_id=recipient_session_id)
+
+
+class UnsendPartnerMessageRequest(BaseModel):
+    session_id: uuid.UUID
+    message_text: str
+
+
+class UnsendPartnerMessageResponse(BaseModel):
+    success: bool
+
+
+@router.post("/unsend-message", response_model=UnsendPartnerMessageResponse)
+async def unsend_message(request: UnsendPartnerMessageRequest, current_user: dict = Depends(get_current_user)):
+    try:
+        user_id = uuid.UUID(current_user.get("sub"))
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid user ID in token")
+
+    message_text = (request.message_text or "").strip()
+    if not message_text:
+        raise HTTPException(status_code=400, detail="message_text required")
+
+    deleted = await delete_partner_message(
+        sender_user_id=user_id,
+        sender_session_id=request.session_id,
+        message_text=message_text,
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Message not found or already deleted")
+
+    return UnsendPartnerMessageResponse(success=True)
 

--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -10,6 +10,8 @@ protocol ChatStreamingDelegate: AnyObject {
     var selectedFriendUserId: UUID? { get }
     var isLoading: Bool { get set }
     var isAssistantTyping: Bool { get set }
+    var thinkingText: String { get set }
+    var thinkingTextDone: Bool { get set }
     var pendingOutgoingUserMessageId: UUID? { get set }
     var assistantScrollTargetId: UUID? { get set }
     var streamingScrollToken: Int { get set }
@@ -252,6 +254,8 @@ final class ChatStreamingController {
 
         delegate.isLoading = true
         delegate.isAssistantTyping = false
+        delegate.thinkingText = ""
+        delegate.thinkingTextDone = false
         receivedAnyAssistantOutput = false
         typingDelayTask?.cancel()
         typingDelayTask = Task { [weak self, weak delegate] in
@@ -506,6 +510,18 @@ final class ChatStreamingController {
                             delegate.setCachedMessages(newMessages, for: sid)
                         }
                     }
+                case .thinking(let text):
+                    Task { @MainActor in
+                        if !self.receivedAnyAssistantOutput {
+                            self.typingDelayTask?.cancel()
+                            delegate.isAssistantTyping = true
+                        }
+                        delegate.thinkingText += text
+                    }
+                case .thinkingDone:
+                    Task { @MainActor in
+                        delegate.thinkingTextDone = true
+                    }
                 case .session(let sid):
                     streamSessionId = sid
                     Task { @MainActor in
@@ -610,7 +626,8 @@ final class ChatStreamingController {
                             self.typingDelayTask?.cancel()
                             delegate.isAssistantTyping = false
                         }
-                        currentSegments.append(.partnerMessage(text))
+                        let currentGhostName = UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName)
+                        currentSegments.append(.partnerMessage(text: text, ghostName: currentGhostName))
                         if sid == delegate.sessionId {
                             var newMessages = delegate.messages
                             let idx: Int = {
@@ -682,8 +699,29 @@ final class ChatStreamingController {
                                     await ChatStore.shared.updateRegenerationCount(messageId: msgId, count: count)
                                 }
                             }
+
+                            // If the assistant message is empty (no segments), clear the
+                            // stored response ID so the next request doesn't chain from a
+                            // broken/empty response, which can cause repeated empty replies.
+                            if let msgId = self.currentAssistantMessageId,
+                               let idx = delegate.messages.firstIndex(where: { $0.id == msgId }) {
+                                let msg = delegate.messages[idx]
+                                let hasContent = msg.segments.contains(where: { seg in
+                                    switch seg {
+                                    case .text(let t): return !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    case .partnerMessage: return true
+                                    default: return false
+                                    }
+                                })
+                                if !hasContent, let sid = delegate.sessionId {
+                                    self.responseIdBySession.removeValue(forKey: sid)
+                                }
+                            }
+
                             delegate.isLoading = false
                             delegate.isAssistantTyping = false
+                            delegate.thinkingText = ""
+                            delegate.thinkingTextDone = false
                             self.isStreaming = false
                             delegate.streamingDidFinish()
                         }
@@ -736,6 +774,8 @@ final class ChatStreamingController {
                             }
                             delegate.isLoading = false
                             delegate.isAssistantTyping = false
+                            delegate.thinkingText = ""
+                            delegate.thinkingTextDone = false
                             self.isStreaming = false
                             self.currentStreamingSessionId = nil
                             delegate.streamingDidFinish()
@@ -772,6 +812,8 @@ final class ChatStreamingController {
                 }
             }
 
+            let ghostNameToSend = UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName)
+
             let task = Task.detached { [streamToken] in
                 let stream = BackendService.shared.streamChatMessage(
                     messageToSend,
@@ -783,7 +825,8 @@ final class ChatStreamingController {
                     friendUserId: friendToUse,
                     messageId: clientMessageId,
                     ephemeral: false,
-                    voiceAgent: voiceAgentToSend
+                    voiceAgent: voiceAgentToSend,
+                    ghostName: ghostNameToSend
                 )
                 for await event in stream {
                     onEvent(event)
@@ -810,6 +853,9 @@ final class ChatStreamingController {
     func stopGeneration() {
         cancelCurrentStream()
         delegate?.isLoading = false
+        delegate?.isAssistantTyping = false
+        delegate?.thinkingText = ""
+        delegate?.thinkingTextDone = false
         isStreaming = false
     }
 
@@ -853,25 +899,35 @@ final class ChatStreamingController {
         delegate.pendingAttachments = []
         onCacheUpdate?()
 
-        // Delete from local DB and server (best-effort, non-blocking)
-        if let anchorId = anchorMessageId, let sid = sessionId {
-            Task.detached {
-                await ChatStore.shared.deleteMessagesAfter(messageId: anchorId, sessionId: sid)
-            }
-            Task.detached {
-                guard let accessToken = await AuthService.shared.getAccessToken() else { return }
-                await BackendService.shared.deleteMessagesAfter(messageId: anchorId, sessionId: sid, accessToken: accessToken)
-            }
-        }
-
         // Store the regeneration count so we can apply it to the new message
         pendingRegenerationCount = previousCount + 1
 
-        // Re-send — sendMessage will create a new user message and stream a new response
-        sendMessage(overrideText: text)
+        // Clear stale response ID for this session so it isn't sent with the retry
+        if let sid = sessionId {
+            responseIdBySession.removeValue(forKey: sid)
+        }
 
-        // Restore input state
-        delegate.inputText = savedInput
-        delegate.pendingAttachments = savedAttachments
+        // Await deletes before re-sending to avoid a race where the delete
+        // removes the newly created message.
+        if let anchorId = anchorMessageId, let sid = sessionId {
+            Task { [weak self, weak delegate] in
+                await ChatStore.shared.deleteMessagesAfter(messageId: anchorId, sessionId: sid, includeAnchor: true)
+
+                if let accessToken = await AuthService.shared.getAccessToken() {
+                    await BackendService.shared.deleteMessagesAfter(messageId: anchorId, sessionId: sid, accessToken: accessToken, includeAnchor: true)
+                }
+
+                await MainActor.run { [weak self, weak delegate] in
+                    guard let self, let delegate else { return }
+                    self.sendMessage(overrideText: text)
+                    delegate.inputText = savedInput
+                    delegate.pendingAttachments = savedAttachments
+                }
+            }
+        } else {
+            sendMessage(overrideText: text)
+            delegate.inputText = savedInput
+            delegate.pendingAttachments = savedAttachments
+        }
     }
 }

--- a/TalkToMe/Chat/Models/ChatMessage.swift
+++ b/TalkToMe/Chat/Models/ChatMessage.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum MessageSegment: Equatable {
     case text(String)
-    case partnerMessage(String)
+    case partnerMessage(text: String, ghostName: String?)
     case partnerReceived(String)
     case imageData(Data)
     case imageURL(String)
@@ -100,7 +100,8 @@ struct ChatMessage: Identifiable {
                         }
                     case "partner_draft":
                         if let txt = dict["text"] as? String, !txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            segs.append(.partnerMessage(txt))
+                            let gn = dict["ghost_name"] as? String
+                            segs.append(.partnerMessage(text: txt, ghostName: gn))
                         }
                     case "partner_received":
                         if let txt = dict["text"] as? String, !txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/TalkToMe/Chat/ViewModels/ChatViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatViewModel.swift
@@ -23,6 +23,8 @@ class ChatViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var isLoadingHistory: Bool = false
     @Published var isAssistantTyping: Bool = false
+    @Published var thinkingText: String = ""
+    @Published var thinkingTextDone: Bool = false
     @Published var initialJumpToken: Int = 0
     @Published var regenerationCounts: [String: Int] = [:]
 
@@ -214,6 +216,33 @@ class ChatViewModel: ObservableObject {
         } catch { }
     }
 
+    func unsendPartnerDraft(_ text: String) async -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard let sid = sessionId else { return false }
+        guard let accessToken = await authService.getAccessToken() else { return false }
+
+        do {
+            try await backend.unsendPartnerMessage(
+                sessionId: sid,
+                messageText: trimmed,
+                accessToken: accessToken
+            )
+            partnerDrafts.unmarkPartnerDraftAsSent(sessionId: sid, messageContent: trimmed)
+
+            // If no other sent drafts remain for this session, clear the friend linkage
+            // so the chat doesn't auto-assume future drafts are for the same person.
+            if !partnerDrafts.hasAnySentDraft(for: sid) {
+                selectedFriendUserId = nil
+                UserDefaults.standard.removeObject(forKey: Self.friendKey(for: sid))
+            }
+
+            return true
+        } catch {
+            return false
+        }
+    }
+
     func sendPartnerDraftViaSession(_ text: String) async {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -283,6 +312,8 @@ class ChatViewModel: ObservableObject {
             self.streamingController.handleSessionPresented(id)
             self.isLoading = self.streamingController.isCurrentlyStreaming(sessionId: id)
             self.isAssistantTyping = false
+            self.thinkingText = ""
+            self.thinkingTextDone = false
             self.pendingInitialJump = true
         }
 

--- a/TalkToMe/Chat/ViewModels/PartnerDraftsViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/PartnerDraftsViewModel.swift
@@ -22,6 +22,18 @@ final class PartnerDraftsViewModel {
         return sentPartnerDrafts.contains(makeKey(sessionId: sessionId, messageContent: messageContent))
     }
 
+    func unmarkPartnerDraftAsSent(sessionId: UUID?, messageContent: String) {
+        guard let sessionId = sessionId else { return }
+        sentPartnerDrafts.remove(makeKey(sessionId: sessionId, messageContent: messageContent))
+        saveSentDrafts()
+    }
+
+    /// Returns true if the session still has at least one sent (not unsent) partner draft.
+    func hasAnySentDraft(for sessionId: UUID) -> Bool {
+        let prefix = sessionId.uuidString + "_"
+        return sentPartnerDrafts.contains(where: { $0.hasPrefix(prefix) })
+    }
+
     func rekeySentDrafts(oldSessionId: UUID, newSessionId: UUID) {
         guard oldSessionId != newSessionId else { return }
         let oldPrefix = oldSessionId.uuidString + "_"

--- a/TalkToMe/Chat/Views/ChatScreenView.swift
+++ b/TalkToMe/Chat/Views/ChatScreenView.swift
@@ -13,6 +13,14 @@ struct ChatScreenView: View {
         chatViewModel.pendingAttachments.isEmpty ? 68 : 220
     }
 
+    private var inputAreaYOffset: CGFloat {
+        isInputFocused.wrappedValue ? 8 : 14
+    }
+
+    private var focusedBottomInset: CGFloat {
+        isInputFocused.wrappedValue ? 10 : 0
+    }
+
     var body: some View {
         MessagesListView(
             chatViewModel: chatViewModel,
@@ -61,8 +69,8 @@ struct ChatScreenView: View {
                 onVoiceModeStop: { chatViewModel.voiceController.stopVoiceModePushToTalk() }
             )
             .frame(minHeight: chatViewModel.pendingAttachments.isEmpty ? inputAreaHeight : nil, alignment: .bottom)
-            .offset(y: 14)
-            .padding(.bottom, isInputFocused.wrappedValue ? 23 : 0)
+            .offset(y: inputAreaYOffset)
+            .padding(.bottom, focusedBottomInset)
             .transition(.move(edge: .bottom).combined(with: .opacity))
         }
         .background(Color(.systemBackground))
@@ -95,7 +103,7 @@ struct ChatScreenView: View {
                 vm.messages = [
                     ChatMessage.text("Hey! Can we talk about yesterday?", isFromUser: true),
                     ChatMessage(segments: [.text("Of course—what's on your mind?")], isFromUser: false),
-                    ChatMessage(segments: [.text("You could say:"), .partnerMessage("I felt dismissed during our talk. Can we revisit it?")], isFromUser: false),
+                    ChatMessage(segments: [.text("You could say:"), .partnerMessage(text: "I felt dismissed during our talk. Can we revisit it?", ghostName: nil)], isFromUser: false),
                     ChatMessage(segments: [.partnerReceived("Absolutely, I'd like that. When works for you?")], isFromUser: false)
                 ]
             }

--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -12,6 +12,7 @@ struct ChatView: View {
     @State private var pendingPartnerDraftText: String? = nil
     @State private var isFriendPickerLoading: Bool = false
     @State private var friendPickerErrorMessage: String? = nil
+    @State private var showAddFriendSheet: Bool = false
 
     @FocusState private var isInputFocused: Bool
 
@@ -114,6 +115,11 @@ struct ChatView: View {
             let content = (note.userInfo?["content"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             guard !content.isEmpty else { return }
             Task { @MainActor in
+                if let friendId = note.userInfo?["friend_user_id"] as? UUID {
+                    viewModel.selectedFriendUserId = friendId
+                    await viewModel.sendPartnerDraftToSelectedFriend(content)
+                    return
+                }
                 if viewModel.isConnectedToFriendInThisChat {
                     await viewModel.sendPartnerDraftViaSession(content)
                     return
@@ -122,6 +128,26 @@ struct ChatView: View {
                 showFriendPicker = true
                 await refreshFriendsForPicker()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .unsendPartnerMessageFromBubble)) { note in
+            let content = (note.userInfo?["content"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !content.isEmpty else { return }
+            Task { @MainActor in
+                let success = await viewModel.unsendPartnerDraft(content)
+                NotificationCenter.default.post(
+                    name: .unsendPartnerMessageResult,
+                    object: nil,
+                    userInfo: ["content": content, "success": success]
+                )
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openAddFriendSheet)) { _ in
+            showAddFriendSheet = true
+        }
+        .sheet(isPresented: $showAddFriendSheet) {
+            FriendsSheetView(isPresented: $showAddFriendSheet)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .animation(nil, value: viewModel.messages.isEmpty)
     }

--- a/TalkToMe/Chat/Views/Components/AssistantMessageActionsView.swift
+++ b/TalkToMe/Chat/Views/Components/AssistantMessageActionsView.swift
@@ -85,7 +85,7 @@ struct AssistantMessageActionsView: View {
         UIPasteboard.general.string = messageText
         Haptics.impact(.light)
         showCopyCheck = true
-        onToast?("Copied response to clipboard.")
+        onToast?("Response copied to clipboard.")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             showCopyCheck = false
         }

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -236,7 +236,7 @@ struct MessageBubbleView: View {
                                 }
                             case .imageData(_), .imageURL(_), .fileData(_, _), .fileURL(_, _):
                                 EmptyView()
-                            case .partnerMessage(let text):
+                            case .partnerMessage(let text, let ghostName):
                                 if !text.isEmpty {
                                     let isSent = chatViewModel.partnerDrafts.isPartnerDraftSent(sessionId: chatViewModel.sessionId, messageContent: text)
                                     let isLinked = chatViewModel.isConnectedToFriendInThisChat
@@ -244,7 +244,8 @@ struct MessageBubbleView: View {
                                         initialText: text,
                                         isSent: isSent,
                                         isLinked: isLinked,
-                                        recipientUserId: chatViewModel.selectedFriendUserId
+                                        recipientUserId: chatViewModel.selectedFriendUserId,
+                                        ghostName: ghostName
                                     ) { action in
                                         switch action {
                                         case .send(let edited):

--- a/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
@@ -5,16 +5,20 @@ struct PartnerDraftBlockView: View {
     enum Action { case send(String) }
 
     @EnvironmentObject private var friendsViewModel: FriendsViewModel
-    @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var buddyName: String = ""
+    @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var currentGlobalBuddyName: String = ""
 
     @State private var text: String
     @State private var isConfirmingNormalSend: Bool = false
     @State private var showSentLocally: Bool = false
+    @State private var showFriendMenu: Bool = false
+    @State private var isConfirmingUnsend: Bool = false
+    @State private var isUnsending: Bool = false
 
     let initialText: String
     let isSent: Bool
     let isLinked: Bool
     let recipientUserId: UUID?
+    let ghostName: String?
     let onAction: (Action) -> Void
 
     init(
@@ -22,23 +26,32 @@ struct PartnerDraftBlockView: View {
         isSent: Bool = false,
         isLinked: Bool = true,
         recipientUserId: UUID?,
+        ghostName: String? = nil,
         onAction: @escaping (Action) -> Void
     ) {
         self.initialText = initialText
         self.isSent = isSent
         self.isLinked = isLinked
         self.recipientUserId = recipientUserId
+        self.ghostName = ghostName
         self._text = State(initialValue: initialText)
         self.onAction = onAction
     }
 
+    /// Use the persisted ghost name if available, otherwise fall back to the current global setting.
+    private var effectiveBuddyName: String {
+        let persisted = ghostName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !persisted.isEmpty { return persisted }
+        return currentGlobalBuddyName
+    }
+
     private var resolvedBuddyName: String {
-        let name = buddyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = effectiveBuddyName.trimmingCharacters(in: .whitespacesAndNewlines)
         return name.isEmpty ? "Your buddy" : name
     }
 
     private var buddyImage: UIImage? {
-        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddyName)
+        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: effectiveBuddyName)
     }
 
     private var recipientFirstName: String {
@@ -49,7 +62,7 @@ struct PartnerDraftBlockView: View {
     }
 
     private var alreadySent: Bool {
-        isLinked && (isSent || showSentLocally)
+        isSent || showSentLocally
     }
 
     var body: some View {
@@ -100,13 +113,14 @@ struct PartnerDraftBlockView: View {
                 .textSelection(.enabled)
                 .padding(.horizontal, 4)
 
-            // Send button
+            // Send / unsend button row
             HStack {
-                if isConfirmingNormalSend {
+                if isConfirmingNormalSend || isConfirmingUnsend {
                     Button(action: {
                         Haptics.impact(.light)
                         withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
                             isConfirmingNormalSend = false
+                            isConfirmingUnsend = false
                         }
                     }) {
                         Text("Cancel")
@@ -119,11 +133,17 @@ struct PartnerDraftBlockView: View {
 
                 Spacer()
 
-                Button(action: handleSendTap) {
+                Button(action: handleButtonTap) {
                     sendButtonContent
                 }
                 .buttonStyle(.plain)
-                .disabled(alreadySent)
+                .disabled(isUnsending)
+            }
+
+            // Inline friend picker menu
+            if showFriendMenu {
+                friendPickerMenu
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
         }
         .padding(14)
@@ -134,22 +154,73 @@ struct PartnerDraftBlockView: View {
         .onAppear {
             isConfirmingNormalSend = false
             showSentLocally = false
+            showFriendMenu = false
+            isConfirmingUnsend = false
+            isUnsending = false
         }
         .onChange(of: initialText) { _, newValue in
             self.text = newValue
             isConfirmingNormalSend = false
             showSentLocally = false
+            showFriendMenu = false
+            isConfirmingUnsend = false
+            isUnsending = false
         }
         .onChange(of: isSent) { _, _ in
             isConfirmingNormalSend = false
+            isConfirmingUnsend = false
+            isUnsending = false
             if isSent { showSentLocally = false }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .unsendPartnerMessageResult)) { note in
+            let content = (note.userInfo?["content"] as? String) ?? ""
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard content == trimmed else { return }
+            let success = (note.userInfo?["success"] as? Bool) ?? false
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                isUnsending = false
+                if success {
+                    showSentLocally = false
+                }
+            }
         }
     }
 
     @ViewBuilder
     private var sendButtonContent: some View {
         ZStack {
-            if alreadySent {
+            if isUnsending {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white)
+                    Text("Unsending")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.red.opacity(0.7))
+                )
+                .transition(.scale.combined(with: .opacity))
+            } else if isConfirmingUnsend {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text("Unsend?")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.red.opacity(0.85))
+                )
+                .transition(.scale.combined(with: .opacity))
+            } else if alreadySent {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark")
                         .font(.system(size: 13, weight: .semibold))
@@ -181,9 +252,9 @@ struct PartnerDraftBlockView: View {
                 .transition(.scale.combined(with: .opacity))
             } else {
                 HStack(spacing: 6) {
-                    Text("Send to \(recipientFirstName)")
+                    Text(isLinked ? "Send to \(recipientFirstName)" : "Send to Friend")
                         .font(.system(size: 14, weight: .semibold))
-                    Image(systemName: "arrow.up.right")
+                    Image(systemName: isLinked ? "arrow.up.right" : (showFriendMenu ? "chevron.down" : "chevron.up"))
                         .font(.system(size: 12, weight: .semibold))
                 }
                 .foregroundColor(.white)
@@ -198,26 +269,133 @@ struct PartnerDraftBlockView: View {
         }
     }
 
-    private func handleSendTap() {
-        guard !alreadySent else { return }
+    @ViewBuilder
+    private var friendPickerMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if !friendsViewModel.friends.isEmpty {
+                Divider()
+                    .padding(.bottom, 4)
+
+                ForEach(friendsViewModel.friends) { friend in
+                    Button {
+                        handleFriendPicked(friend)
+                    } label: {
+                        HStack(spacing: 10) {
+                            SidebarAvatarView(avatarURL: friend.avatarURL)
+                                .frame(width: 30, height: 30)
+                                .clipShape(Circle())
+
+                            Text(firstName(of: friend))
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundColor(.primary)
+
+                            Spacer()
+
+                            Image(systemName: "arrow.up.right")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Divider()
+                .padding(.vertical, 4)
+
+            Button {
+                Haptics.impact(.light)
+                withAnimation(.spring(response: 0.25)) {
+                    showFriendMenu = false
+                }
+                NotificationCenter.default.post(name: .openAddFriendSheet, object: nil)
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "person.badge.plus")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.accentColor)
+                        .frame(width: 30, height: 30)
+
+                    Text("Add a friend")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.accentColor)
+
+                    Spacer()
+                }
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.top, 4)
+    }
+
+    private func handleButtonTap() {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
         Haptics.impact(.light)
 
-        if isConfirmingNormalSend {
+        if isConfirmingUnsend {
+            // Execute unsend
             withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                if isLinked {
-                    showSentLocally = true
-                }
-                isConfirmingNormalSend = false
+                isConfirmingUnsend = false
+                isUnsending = true
             }
-            onAction(.send(trimmed))
-        } else {
+            NotificationCenter.default.post(
+                name: .unsendPartnerMessageFromBubble,
+                object: nil,
+                userInfo: ["content": trimmed]
+            )
+        } else if alreadySent {
+            // Show unsend confirmation
             withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                isConfirmingNormalSend = true
+                isConfirmingUnsend = true
+            }
+        } else if isLinked {
+            if isConfirmingNormalSend {
+                withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                    showSentLocally = true
+                    isConfirmingNormalSend = false
+                }
+                onAction(.send(trimmed))
+            } else {
+                withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                    isConfirmingNormalSend = true
+                }
+            }
+        } else {
+            withAnimation(.spring(response: 0.25)) {
+                showFriendMenu.toggle()
+            }
+            if friendsViewModel.friends.isEmpty {
+                Task { try? await friendsViewModel.loadFriends() }
             }
         }
+    }
+
+    private func handleFriendPicked(_ friend: FriendSummary) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        Haptics.impact(.light)
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+            showFriendMenu = false
+            showSentLocally = true
+        }
+
+        NotificationCenter.default.post(
+            name: .sendPartnerMessageFromBubble,
+            object: nil,
+            userInfo: ["content": trimmed, "friend_user_id": friend.id]
+        )
+    }
+
+    private func firstName(of friend: FriendSummary) -> String {
+        let full = friend.fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return full.split(separator: " ").first.map(String.init) ?? "Friend"
     }
 }
 

--- a/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
+++ b/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct ThinkingIndicatorView: View {
+
+    let thinkingText: String
+    let thinkingTextDone: Bool
+
+    private var hasSummaryTokens: Bool {
+        !thinkingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var summaryText: String {
+        thinkingText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var statusFont: Font {
+        .system(size: 17, weight: .regular)
+    }
+
+    var body: some View {
+        Group {
+            if hasSummaryTokens {
+                VStack(alignment: .leading, spacing: 6) {
+                    ShimmeringStatusText(
+                        text: "Thinking",
+                        font: statusFont,
+                        color: .secondary
+                    )
+                        .padding(.vertical, 6)
+
+                    Text(summaryText)
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary.opacity(0.82))
+                        .lineSpacing(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.horizontal, 4)
+            } else {
+                HStack(spacing: 6) {
+                    ShimmeringStatusText(
+                        text: "Generating",
+                        font: statusFont,
+                        color: .secondary
+                    )
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 6)
+            }
+        }
+    }
+}
+
+private struct ShimmeringStatusText: View {
+    let text: String
+    let font: Font
+    let color: Color
+
+    @State private var phase: CGFloat = -1.0
+
+    var body: some View {
+        Text(text)
+            .font(font)
+            .foregroundColor(color)
+            .overlay(
+                GeometryReader { geo in
+                    let width = max(geo.size.width, 1)
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.0), location: 0.0),
+                            .init(color: .white.opacity(0.08), location: 0.30),
+                            .init(color: .white.opacity(0.28), location: 0.50),
+                            .init(color: .white.opacity(0.08), location: 0.70),
+                            .init(color: .white.opacity(0.0), location: 1.0),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .frame(width: width * 0.95)
+                    .blur(radius: 0.6)
+                    .offset(x: phase * width * 2.2)
+                    .blendMode(.screen)
+                }
+                .mask(
+                    Text(text)
+                        .font(font)
+                )
+                .allowsHitTesting(false)
+            )
+            .onAppear {
+                phase = -1.0
+                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
+                    phase = 1.0
+                }
+            }
+            .onDisappear {
+                phase = -1.0
+            }
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 20) {
+        ThinkingIndicatorView(thinkingText: "", thinkingTextDone: false)
+        ThinkingIndicatorView(thinkingText: "Analyzing the user's request and considering how to respond...", thinkingTextDone: true)
+        ThinkingIndicatorView(thinkingText: "", thinkingTextDone: false)
+    }
+    .padding()
+}

--- a/TalkToMe/Chat/Views/Components/ToastOverlayView.swift
+++ b/TalkToMe/Chat/Views/Components/ToastOverlayView.swift
@@ -7,7 +7,7 @@ struct ToastOverlayView: View {
     var body: some View {
         HStack(spacing: 12) {
             Text(message)
-                .font(.system(size: 13, weight: .regular))
+                .font(.system(size: 15, weight: .medium))
                 .foregroundColor(.primary)
                 .lineLimit(2)
 
@@ -16,14 +16,16 @@ struct ToastOverlayView: View {
             if let onDismiss {
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 13, weight: .bold))
                         .foregroundColor(.secondary)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
         .frame(maxWidth: .infinity)
         .background {
             if #available(iOS 26.0, *) {

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -76,8 +76,11 @@ struct MessagesListView: View {
                 }
                 if isAssistantTyping {
                     HStack(alignment: .top, spacing: 0) {
-                        TypingIndicatorView(showAfter: 0)
-                            .padding(.top, -10)
+                        ThinkingIndicatorView(
+                            thinkingText: chatViewModel.thinkingText,
+                            thinkingTextDone: chatViewModel.thinkingTextDone
+                        )
+                        .padding(.top, -10)
                         Spacer(minLength: 0)
                     }
                 }

--- a/TalkToMe/Services/Backend/BackendService.swift
+++ b/TalkToMe/Services/Backend/BackendService.swift
@@ -32,6 +32,8 @@ struct BackendService {
         case toolArgs(String)
         case toolDone
         case responseId(String)
+        case thinking(String)
+        case thinkingDone
         case done
         case error(String)
     }

--- a/TalkToMe/Services/Backend/BackendServiceChat.swift
+++ b/TalkToMe/Services/Backend/BackendServiceChat.swift
@@ -36,7 +36,8 @@ extension BackendService {
         friendUserId: UUID? = nil,
         messageId: UUID? = nil,
         ephemeral: Bool = false,
-        voiceAgent: String? = nil
+        voiceAgent: String? = nil,
+        ghostName: String? = nil
     ) -> AsyncStream<StreamEvent> {
         var request = URLRequest(url: baseURL
             .appendingPathComponent("chat")
@@ -56,7 +57,8 @@ extension BackendService {
             attachments: attachments,
             friend_user_id: friendUserId,
             ephemeral: ephemeral ? true : nil,
-            voice_agent: (voiceAgent?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : voiceAgent
+            voice_agent: (voiceAgent?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : voiceAgent,
+            ghost_name: (ghostName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : ghostName
         )
         request.httpBody = try? jsonEncoder.encode(payload)
         return SSEService.shared.stream(request: request)
@@ -225,15 +227,18 @@ extension BackendService {
 
     /// Best-effort deletion of all messages in a session after a given message.
     /// Silently ignores 404 (backend may not support this endpoint yet).
-    func deleteMessagesAfter(messageId: UUID, sessionId: UUID, accessToken: String) async {
-        let url = baseURL
+    func deleteMessagesAfter(messageId: UUID, sessionId: UUID, accessToken: String, includeAnchor: Bool = false) async {
+        var components = URLComponents(url: baseURL
             .appendingPathComponent("chat")
             .appendingPathComponent("sessions")
             .appendingPathComponent(sessionId.uuidString)
             .appendingPathComponent("messages")
             .appendingPathComponent("after")
-            .appendingPathComponent(messageId.uuidString)
-        var request = URLRequest(url: url)
+            .appendingPathComponent(messageId.uuidString), resolvingAgainstBaseURL: false)!
+        if includeAnchor {
+            components.queryItems = [URLQueryItem(name: "include_anchor", value: "true")]
+        }
+        var request = URLRequest(url: components.url!)
         request.httpMethod = "DELETE"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = BackendService.coreRequestTimeoutSeconds
@@ -293,6 +298,7 @@ private struct ChatRequestBody: Codable {
     let friend_user_id: UUID?
     let ephemeral: Bool?
     let voice_agent: String?
+    let ghost_name: String?
 }
 
 private struct MessagesResponseBody: Codable {

--- a/TalkToMe/Services/Backend/BackendServicePartner.swift
+++ b/TalkToMe/Services/Backend/BackendServicePartner.swift
@@ -39,5 +39,35 @@ extension BackendService {
 
         return try jsonDecoder.decode(SendPartnerMessageResponse.self, from: data)
     }
+
+    private struct UnsendPartnerMessageRequest: Codable {
+        let session_id: UUID
+        let message_text: String
+    }
+
+    func unsendPartnerMessage(
+        sessionId: UUID,
+        messageText: String,
+        accessToken: String
+    ) async throws {
+        let url = baseURL
+            .appendingPathComponent("partner")
+            .appendingPathComponent("unsend-message")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = BackendService.coreRequestTimeoutSeconds
+
+        let payload = UnsendPartnerMessageRequest(session_id: sessionId, message_text: messageText)
+        request.httpBody = try jsonEncoder.encode(payload)
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let serverMessage = decodeSimpleDetail(from: data) ?? String(data: data, encoding: .utf8) ?? "Unknown server error"
+            throw NSError(domain: "Backend", code: (response as? HTTPURLResponse)?.statusCode ?? -1, userInfo: [NSLocalizedDescriptionKey: serverMessage])
+        }
+    }
 }
 

--- a/TalkToMe/Services/Backend/SSEService.swift
+++ b/TalkToMe/Services/Backend/SSEService.swift
@@ -72,6 +72,13 @@ final class SSEService {
                             continuation.yield(.toolArgs(dataString))
                         } else if event == "tool_done" {
                             continuation.yield(.toolDone)
+                        } else if event == "thinking" {
+                            let text = decodeTokenPayload(dataString)
+                            if !text.isEmpty {
+                                continuation.yield(.thinking(text))
+                            }
+                        } else if event == "thinking_done" {
+                            continuation.yield(.thinkingDone)
                         } else if event == "done" {
                             continuation.yield(.done)
                             continuation.finish()
@@ -107,6 +114,13 @@ final class SSEService {
                             if currentEvent == "token" {
                                 let token = decodeTokenPayload(value)
                                 continuation.yield(.token(token))
+                                currentEvent = nil
+                                dataLines.removeAll(keepingCapacity: false)
+                            } else if currentEvent == "thinking" {
+                                let text = decodeTokenPayload(value)
+                                if !text.isEmpty {
+                                    continuation.yield(.thinking(text))
+                                }
                                 currentEvent = nil
                                 dataLines.removeAll(keepingCapacity: false)
                             } else {

--- a/TalkToMe/Services/GRDB-Service/ChatStore.swift
+++ b/TalkToMe/Services/GRDB-Service/ChatStore.swift
@@ -239,8 +239,8 @@ final class ChatStore {
     }
 
     /// Deletes all messages in a session that come after the given message (by created_at).
-    /// The anchor message itself is preserved.
-    func deleteMessagesAfter(messageId: UUID, sessionId: UUID) async {
+    /// When `includeAnchor` is true the anchor message itself is also deleted.
+    func deleteMessagesAfter(messageId: UUID, sessionId: UUID, includeAnchor: Bool = false) async {
         let mid = messageId.uuidString
         let sid = sessionId.uuidString
 
@@ -254,29 +254,45 @@ final class ChatStore {
                     arguments: [mid]
                 ) else { return [] }
 
-                // Collect attachment files for messages to be deleted
-                let rels = try String.fetchAll(
-                    db,
-                    sql: """
-                    SELECT a.local_relpath
-                    FROM attachments a
-                    JOIN messages m ON m.id = a.message_id
-                    WHERE m.session_id = ?
-                      AND (m.created_at > ? OR (m.created_at = ? AND m.id != ?))
-                      AND a.local_relpath IS NOT NULL
-                    """,
-                    arguments: [sid, anchorCreatedAt, anchorCreatedAt, mid]
-                )
-
-                // Delete the messages (attachments cascade via FK)
-                try db.execute(
-                    sql: """
-                    DELETE FROM messages
-                    WHERE session_id = ?
-                      AND (created_at > ? OR (created_at = ? AND id != ?))
-                    """,
-                    arguments: [sid, anchorCreatedAt, anchorCreatedAt, mid]
-                )
+                let rels: [String]
+                if includeAnchor {
+                    rels = try String.fetchAll(
+                        db,
+                        sql: """
+                        SELECT a.local_relpath
+                        FROM attachments a
+                        JOIN messages m ON m.id = a.message_id
+                        WHERE m.session_id = ? AND m.created_at >= ?
+                          AND a.local_relpath IS NOT NULL
+                        """,
+                        arguments: [sid, anchorCreatedAt]
+                    )
+                    try db.execute(
+                        sql: "DELETE FROM messages WHERE session_id = ? AND created_at >= ?",
+                        arguments: [sid, anchorCreatedAt]
+                    )
+                } else {
+                    rels = try String.fetchAll(
+                        db,
+                        sql: """
+                        SELECT a.local_relpath
+                        FROM attachments a
+                        JOIN messages m ON m.id = a.message_id
+                        WHERE m.session_id = ?
+                          AND (m.created_at > ? OR (m.created_at = ? AND m.id != ?))
+                          AND a.local_relpath IS NOT NULL
+                        """,
+                        arguments: [sid, anchorCreatedAt, anchorCreatedAt, mid]
+                    )
+                    try db.execute(
+                        sql: """
+                        DELETE FROM messages
+                        WHERE session_id = ?
+                          AND (created_at > ? OR (created_at = ? AND id != ?))
+                        """,
+                        arguments: [sid, anchorCreatedAt, anchorCreatedAt, mid]
+                    )
+                }
 
                 return rels
             }

--- a/TalkToMe/Shared/Notifications.swift
+++ b/TalkToMe/Shared/Notifications.swift
@@ -15,4 +15,7 @@ extension Notification.Name {
     static let partnerMessageReceived = Notification.Name("partner.message.received")
     static let partnerRequestAccepted = Notification.Name("partner.request.accepted")
     static let sendPartnerMessageFromBubble = Notification.Name("chat.partner.send.from.bubble")
+    static let unsendPartnerMessageFromBubble = Notification.Name("chat.partner.unsend.from.bubble")
+    static let unsendPartnerMessageResult = Notification.Name("chat.partner.unsend.result")
+    static let openAddFriendSheet = Notification.Name("chat.open.add.friend.sheet")
 }

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -311,7 +311,7 @@ private struct HeaderCircleStyle: ViewModifier {
 
 // MARK: - Friends Sheet
 
-private struct FriendsSheetView: View {
+struct FriendsSheetView: View {
     @Binding var isPresented: Bool
     @EnvironmentObject private var friendsViewModel: FriendsViewModel
 


### PR DESCRIPTION
This PR fixes response-streaming reliability issues and adds stronger server/client diagnostics for empty or missing reasoning output. It also wires full unsend and regeneration-cleanup flows across backend and iOS local/remote stores. The chat indicator UX is updated to use a simplified shimmering Generating/Thinking presentation with live summary text handling. Additional polish includes tighter keyboard spacing for the input area and the compact send-to-friend menu flow updates.