### PR TITLE
Fix regenerate to preserve message position and improve thinking indicator

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -104,7 +104,7 @@ final class ChatStreamingController {
         }
     }
 
-    func sendMessage(overrideText: String? = nil) {
+    func sendMessage(overrideText: String? = nil, isRegeneration: Bool = false, reuseMessageId: UUID? = nil) {
         guard let delegate else { return }
 
         let trimmedMessage = (overrideText ?? delegate.inputText).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -201,39 +201,60 @@ final class ChatStreamingController {
             }
         }
 
-        let persistedContent: String = {
-            guard !attachmentsToSend.isEmpty else { return messageToSend }
-            let obj: [String: Any] = ["_talktome": ["type": "segments", "segments": segs]]
-            let data = (try? JSONSerialization.data(withJSONObject: obj)) ?? Data()
-            return String(data: data, encoding: .utf8) ?? messageToSend
-        }()
+        let clientMessageId: UUID
 
-        let dto = BackendService.ChatMessageDTO(
-            id: UUID(),
-            user_id: userId,
-            session_id: sid,
-            role: "user",
-            content: persistedContent,
-            created_at: ISO8601DateFormatter().string(from: Date())
-        )
-        let clientMessageId = dto.id
+        if !isRegeneration {
+            let persistedContent: String = {
+                guard !attachmentsToSend.isEmpty else { return messageToSend }
+                let obj: [String: Any] = ["_talktome": ["type": "segments", "segments": segs]]
+                let data = (try? JSONSerialization.data(withJSONObject: obj)) ?? Data()
+                return String(data: data, encoding: .utf8) ?? messageToSend
+            }()
 
-        let localMessage = ChatMessage(dto: dto, currentUserId: userId)
-        delegate.messages.append(localMessage)
-        delegate.pendingOutgoingUserMessageId = clientMessageId
-        onCacheUpdate?()
-        Task.detached {
-            await ChatStore.shared.upsertMessages([dto])
+            let dto = BackendService.ChatMessageDTO(
+                id: UUID(),
+                user_id: userId,
+                session_id: sid,
+                role: "user",
+                content: persistedContent,
+                created_at: ISO8601DateFormatter().string(from: Date())
+            )
+            clientMessageId = dto.id
+
+            let localMessage = ChatMessage(dto: dto, currentUserId: userId)
+            delegate.messages.append(localMessage)
+            delegate.pendingOutgoingUserMessageId = clientMessageId
+            onCacheUpdate?()
+            Task.detached {
+                await ChatStore.shared.upsertMessages([dto])
+            }
+
+            NotificationCenter.default.post(name: .chatMessageSent, object: nil, userInfo: [
+                "sessionId": sid,
+                "messageContent": previewToSend
+            ])
+            NotificationCenter.default.post(name: .chatSessionsNeedRefresh, object: nil)
+
+            delegate.inputText = ""
+            delegate.pendingAttachments = []
+        } else {
+            // Regeneration: persist the user message to local DB (the old one
+            // was deleted) but don't add it to the messages array — the original
+            // row is still visible in the UI for a seamless experience.
+            // Reuse the original message ID so the UI and DB stay in sync on reload.
+            let dto = BackendService.ChatMessageDTO(
+                id: reuseMessageId ?? UUID(),
+                user_id: userId,
+                session_id: sid,
+                role: "user",
+                content: messageToSend,
+                created_at: ISO8601DateFormatter().string(from: Date())
+            )
+            clientMessageId = dto.id
+            Task.detached {
+                await ChatStore.shared.upsertMessages([dto])
+            }
         }
-
-        NotificationCenter.default.post(name: .chatMessageSent, object: nil, userInfo: [
-            "sessionId": sid,
-            "messageContent": previewToSend
-        ])
-        NotificationCenter.default.post(name: .chatSessionsNeedRefresh, object: nil)
-
-        delegate.inputText = ""
-        delegate.pendingAttachments = []
 
         if NetworkMonitor.shared.isOnline == false {
             Task.detached {
@@ -908,8 +929,11 @@ final class ChatStreamingController {
         let savedInput = delegate.inputText
         let savedAttachments = delegate.pendingAttachments
 
-        // Remove the user message and everything after it (assistant message + any subsequent messages)
-        delegate.messages.removeSubrange(removeFrom...)
+        // Keep the user message in place; only remove the assistant message and everything after it
+        let removeAfterUser = removeFrom + 1
+        if removeAfterUser < delegate.messages.count {
+            delegate.messages.removeSubrange(removeAfterUser...)
+        }
         delegate.pendingAttachments = []
         onCacheUpdate?()
 
@@ -925,6 +949,7 @@ final class ChatStreamingController {
         // removes the newly created message.
         if let anchorId = anchorMessageId, let sid = sessionId {
             Task { [weak self, weak delegate] in
+                // Delete the user message + everything after from DB (sendMessage will re-persist it)
                 await ChatStore.shared.deleteMessagesAfter(messageId: anchorId, sessionId: sid, includeAnchor: true)
 
                 if let accessToken = await AuthService.shared.getAccessToken() {
@@ -933,13 +958,13 @@ final class ChatStreamingController {
 
                 await MainActor.run { [weak self, weak delegate] in
                     guard let self, let delegate else { return }
-                    self.sendMessage(overrideText: text)
+                    self.sendMessage(overrideText: text, isRegeneration: true, reuseMessageId: anchorId)
                     delegate.inputText = savedInput
                     delegate.pendingAttachments = savedAttachments
                 }
             }
         } else {
-            sendMessage(overrideText: text)
+            sendMessage(overrideText: text, isRegeneration: true, reuseMessageId: anchorMessageId)
             delegate.inputText = savedInput
             delegate.pendingAttachments = savedAttachments
         }

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -170,6 +170,31 @@ struct MessageBubbleView: View {
 
     @Environment(\.colorScheme) private var colorScheme
     
+    /// True for the streaming placeholder row where generation starts.
+    private var shouldShowThinkingIndicator: Bool {
+        guard !message.isFromUser else { return false }
+        guard !message.isFromPartnerUser else { return false }
+        guard chatViewModel.isAssistantTyping else { return false }
+        guard chatViewModel.messages.last?.id == message.id else { return false }
+        return !hasRenderableAssistantContent
+    }
+
+    private var hasRenderableAssistantContent: Bool {
+        if message.isToolLoading { return true }
+        return message.segments.contains { segment in
+            switch segment {
+            case .text(let text):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .partnerMessage(let text, _):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .partnerReceived(let text):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .imageData(_), .imageURL(_), .fileData(_, _), .fileURL(_, _):
+                return true
+            }
+        }
+    }
+
     /// Whether to show action buttons under assistant messages
     private var shouldShowAssistantActions: Bool {
         // Don't show for user messages
@@ -213,13 +238,18 @@ struct MessageBubbleView: View {
                 }
             } else {
                 VStack(alignment: .leading, spacing: 8) {
-                    if message.isFromPartnerUser {
+                    if shouldShowThinkingIndicator {
+                        ThinkingIndicatorView(
+                            thinkingText: chatViewModel.thinkingText,
+                            thinkingTextDone: chatViewModel.thinkingTextDone
+                        )
+                        .padding(.vertical, 4)
+                    } else if message.isFromPartnerUser {
                         PartnerMessageBlockView(
                             text: plainText(from: message.segments),
                             senderUserId: message.senderUserId
                         )
-                    } else
-                    if !message.segments.isEmpty {
+                    } else if !message.segments.isEmpty {
                         let attachmentSegments = message.segments.filter { isAttachmentSegment($0) }
                         if !attachmentSegments.isEmpty {
                             attachmentsView(segments: attachmentSegments, alignment: .leading)

--- a/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
+++ b/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
@@ -13,8 +13,15 @@ struct ThinkingIndicatorView: View {
         thinkingText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var plainSummaryText: String {
+        if let parsed = try? AttributedString(markdown: summaryText) {
+            return String(parsed.characters)
+        }
+        return summaryText
+    }
+
     private var statusFont: Font {
-        .system(size: 17, weight: .regular)
+        .body
     }
 
     var body: some View {
@@ -26,11 +33,11 @@ struct ThinkingIndicatorView: View {
                         font: statusFont,
                         color: .secondary
                     )
-                        .padding(.vertical, 6)
+                        .padding(.bottom, 4)
 
-                    Text(summaryText)
+                    Text(plainSummaryText)
                         .font(.system(size: 14))
-                        .foregroundColor(.secondary.opacity(0.82))
+                        .foregroundStyle(.secondary)
                         .lineSpacing(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -44,7 +51,7 @@ struct ThinkingIndicatorView: View {
                     )
                 }
                 .padding(.horizontal, 4)
-                .padding(.vertical, 6)
+                .padding(.bottom, 4)
             }
         }
     }
@@ -58,43 +65,46 @@ private struct ShimmeringStatusText: View {
     @State private var phase: CGFloat = -1.0
 
     var body: some View {
-        Text(text)
-            .font(font)
-            .foregroundColor(color)
-            .overlay(
-                GeometryReader { geo in
-                    let width = max(geo.size.width, 1)
-                    LinearGradient(
-                        stops: [
-                            .init(color: .white.opacity(0.0), location: 0.0),
-                            .init(color: .white.opacity(0.08), location: 0.30),
-                            .init(color: .white.opacity(0.28), location: 0.50),
-                            .init(color: .white.opacity(0.08), location: 0.70),
-                            .init(color: .white.opacity(0.0), location: 1.0),
-                        ],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .frame(width: width * 0.95)
-                    .blur(radius: 0.6)
-                    .offset(x: phase * width * 2.2)
-                    .blendMode(.screen)
-                }
+        ZStack(alignment: .leading) {
+            // Base text in secondary color
+            Text(text)
+                .font(font)
+                .foregroundColor(color)
+
+            // Bright sweep layer masked to the text shape
+            Text(text)
+                .font(font)
+                .foregroundColor(.primary)
                 .mask(
-                    Text(text)
-                        .font(font)
+                    GeometryReader { geo in
+                        let width = max(geo.size.width, 1)
+                        LinearGradient(
+                            stops: [
+                                .init(color: .clear, location: 0.0),
+                                .init(color: .white.opacity(0.45), location: 0.20),
+                                .init(color: .white.opacity(0.75), location: 0.50),
+                                .init(color: .white.opacity(0.45), location: 0.80),
+                                .init(color: .clear, location: 1.0),
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: width * 1.6)
+                        .blur(radius: 2)
+                        .offset(x: phase * width * 2.2)
+                    }
                 )
                 .allowsHitTesting(false)
-            )
-            .onAppear {
-                phase = -1.0
-                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
-                    phase = 1.0
-                }
+        }
+        .onAppear {
+            phase = -1.0
+            withAnimation(.linear(duration: 1.3).repeatForever(autoreverses: false)) {
+                phase = 1.0
             }
-            .onDisappear {
-                phase = -1.0
-            }
+        }
+        .onDisappear {
+            phase = -1.0
+        }
     }
 }
 

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -21,7 +21,6 @@ struct MessagesListView: View {
     @State private var toastWorkItem: DispatchWorkItem? = nil
 
     private var messages: [ChatMessage] { chatViewModel.messages }
-    private var isAssistantTyping: Bool { chatViewModel.isAssistantTyping }
     private var initialJumpToken: Int { chatViewModel.initialJumpToken }
 
     private let nearBottomThreshold: CGFloat = 20
@@ -73,16 +72,6 @@ struct MessagesListView: View {
                     .opacity(message.id == outgoingSourceMessageId ? 0 : 1)
                     .animation(nil, value: outgoingSourceMessageId)
                     .padding(.top, index > 0 && (messages[index - 1].isFromUser != message.isFromUser) ? 4 : 0)
-                }
-                if isAssistantTyping {
-                    HStack(alignment: .top, spacing: 0) {
-                        ThinkingIndicatorView(
-                            thinkingText: chatViewModel.thinkingText,
-                            thinkingTextDone: chatViewModel.thinkingTextDone
-                        )
-                        .padding(.top, -10)
-                        Spacer(minLength: 0)
-                    }
                 }
             }
             .padding(.top, 24)


### PR DESCRIPTION
## Summary

- Move thinking indicator into message bubble with matching padding so it appears exactly where response text renders
- Fix regenerate to keep user message in place without send animation or visual flashing
- Preserve original message ID on regenerate so UI and DB stay in sync
- Tone down shimmer effect on "Generating"/"Thinking" text for subtler appearance
- Remove thinking indicator from MessagesListView since it's now part of MessageBubbleView

🤖 Generated with Claude Code