### PR TITLE
Align Thinking indicator with Generating and persist regeneration count

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -715,6 +715,7 @@ final class ChatStreamingController {
                             if self.currentStreamingSessionId == sid { self.currentStreamingSessionId = nil }
                         }
                     } else {
+                        let capturedRegenCount = self.pendingRegenerationCount
                         Task { @MainActor in
                             // Apply regeneration count to the completed message
                             if self.pendingRegenerationCount > 0,
@@ -723,10 +724,6 @@ final class ChatStreamingController {
                                 let count = self.pendingRegenerationCount
                                 delegate.messages[idx].regenerationCount = count
                                 self.pendingRegenerationCount = 0
-                                // Persist to local DB
-                                Task.detached {
-                                    await ChatStore.shared.updateRegenerationCount(messageId: msgId, count: count)
-                                }
                             }
 
                             // Save thinking summary to the completed message (in-memory for immediate display)
@@ -785,6 +782,9 @@ final class ChatStreamingController {
                                         }
                                         if !capturedThinkingSummary.isEmpty {
                                             await ChatStore.shared.setThinkingSummaryForLastAssistant(sessionId: sid, summary: capturedThinkingSummary)
+                                        }
+                                        if capturedRegenCount > 0 {
+                                            await ChatStore.shared.setRegenerationCountForLastAssistant(sessionId: sid, count: capturedRegenCount)
                                         }
                                     }
                                 }

--- a/TalkToMe/Chat/ViewModels/ChatMessagesViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatMessagesViewModel.swift
@@ -116,11 +116,14 @@ final class ChatMessagesViewModel: ObservableObject {
             guard let userId = resolvedCurrentUserId() else { self.isLoadingHistory = false; return }
             var mapped = dtos.map { ChatMessage(dto: $0, currentUserId: userId) }
 
-            // Merge local-only fields (thinking_summary) that aren't in server DTOs
+            // Merge local-only fields (thinking_summary, regeneration_count) that aren't in server DTOs
             let localMetadata = await ChatStore.shared.loadLocalMetadata(sessionId: sid)
             for i in mapped.indices {
                 if let meta = localMetadata[mapped[i].id.uuidString] {
                     mapped[i].thinkingSummary = meta.thinkingSummary
+                    if meta.regenerationCount > 0 {
+                        mapped[i].regenerationCount = meta.regenerationCount
+                    }
                 }
             }
 

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -368,9 +368,17 @@ struct MessageBubbleView: View {
                 }
             }) {
                 HStack(spacing: 6) {
-                    Text("Thinking")
-                        .font(.body)
-                        .foregroundColor(.secondary)
+                    if alwaysExpanded {
+                        ShimmeringStatusText(
+                            text: "Thinking",
+                            font: .body,
+                            color: .secondary
+                        )
+                    } else {
+                        Text("Thinking")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                    }
                     Image(systemName: expanded ? "chevron.down" : "chevron.right")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(.secondary)
@@ -403,7 +411,7 @@ struct MessageBubbleView: View {
             }
         }
         .padding(.horizontal, 4)
-        .padding(.bottom, 6)
+        .padding(.vertical, 4)
     }
 
     private func isAttachmentSegment(_ seg: MessageSegment) -> Bool {

--- a/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
+++ b/TalkToMe/Chat/Views/Components/ThinkingIndicatorView.swift
@@ -51,13 +51,12 @@ struct ThinkingIndicatorView: View {
                     )
                 }
                 .padding(.horizontal, 4)
-                .padding(.bottom, 4)
             }
         }
     }
 }
 
-private struct ShimmeringStatusText: View {
+struct ShimmeringStatusText: View {
     let text: String
     let font: Font
     let color: Color

--- a/TalkToMe/Services/GRDB-Service/ChatStore.swift
+++ b/TalkToMe/Services/GRDB-Service/ChatStore.swift
@@ -307,23 +307,32 @@ final class ChatStore {
 
     struct MessageLocalMetadata {
         let thinkingSummary: String?
+        let regenerationCount: Int
     }
 
-    /// Returns local-only metadata (thinking_summary) for all messages in a session, keyed by message ID.
+    /// Returns local-only metadata (thinking_summary, regeneration_count) for all messages in a session, keyed by message ID.
     func loadLocalMetadata(sessionId: UUID) async -> [String: MessageLocalMetadata] {
         let sid = sessionId.uuidString
         do {
             return try await dbQueue.read { db in
                 let rows = try Row.fetchAll(
                     db,
-                    sql: "SELECT id, thinking_summary FROM messages WHERE session_id = ? AND thinking_summary IS NOT NULL AND thinking_summary != ''",
+                    sql: """
+                    SELECT id, thinking_summary, regeneration_count FROM messages
+                    WHERE session_id = ?
+                      AND (
+                        (thinking_summary IS NOT NULL AND thinking_summary != '')
+                        OR regeneration_count > 0
+                      )
+                    """,
                     arguments: [sid]
                 )
                 var result: [String: MessageLocalMetadata] = [:]
                 for row in rows {
                     let id: String = row["id"]
                     let ts: String? = row["thinking_summary"]
-                    result[id] = MessageLocalMetadata(thinkingSummary: ts)
+                    let rc: Int = row["regeneration_count"] ?? 0
+                    result[id] = MessageLocalMetadata(thinkingSummary: ts, regenerationCount: rc)
                 }
                 return result
             }
@@ -348,6 +357,27 @@ final class ChatStore {
                     )
                     """,
                     arguments: [summary, sid]
+                )
+            }
+        } catch {}
+    }
+
+    /// Sets regeneration_count on the last assistant message in a session.
+    func setRegenerationCountForLastAssistant(sessionId: UUID, count: Int) async {
+        let sid = sessionId.uuidString
+        do {
+            try await dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    UPDATE messages SET regeneration_count = ?
+                    WHERE id = (
+                        SELECT id FROM messages
+                        WHERE session_id = ? AND role = 'assistant'
+                        ORDER BY created_at DESC
+                        LIMIT 1
+                    )
+                    """,
+                    arguments: [count, sid]
                 )
             }
         } catch {}


### PR DESCRIPTION
## Summary

- **Thinking/Generating alignment:** Both indicators now use the shimmering effect and consistent `.padding(.vertical, 4)` 
- **Regeneration counter persistence:** Counter now survives app restarts and message history reloads by persisting after server reconciliation

## Changes

1. **UI alignment:** Made `ShimmeringStatusText` public so MessageBubbleView can apply shimmer to "Thinking" during active streaming, matching "Generating" appearance
2. **Regeneration persistence:** Added `setRegenerationCountForLastAssistant()` to persist count after server reconciliation (similar to thinking summary pattern)
3. **Metadata merge:** Extended `loadLocalMetadata` to restore both thinking summary and regeneration count when messages are fetched from server

## Test plan

- Stream a message and regenerate to verify "x2" badge shows after response completes
- Close app and reopen to confirm regeneration count persists
- Verify thinking label and generating badge have matching shine effect and vertical alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)