### PR TITLE
Add friend online status to settings

### DIFF
--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -438,6 +438,12 @@ struct MessageBubbleView: View {
         guard !message.isFromPartnerUser else { return false }
         guard message.isFromVoiceMode else { return false }
         guard !message.isToolLoading else { return false }
+        // Don't show on error messages
+        let isError = message.segments.contains { seg in
+            if case .text(let t) = seg { return t.hasPrefix("Error:") }
+            return false
+        }
+        if isError { return false }
         let isLastAssistant = chatViewModel.messages.last { !$0.isFromUser }?.id == message.id
         if isLastAssistant {
             if chatViewModel.isLoading { return false }

--- a/TalkToMe/Friends/Models/FriendSummary.swift
+++ b/TalkToMe/Friends/Models/FriendSummary.swift
@@ -45,21 +45,21 @@ struct FriendSummary: Codable, Hashable, Identifiable {
         guard let date = parsedLastSeenAt else { return nil }
         let elapsed = Date().timeIntervalSince(date)
         if elapsed < 60 {
-            return "Just now"
+            return "Last active just now"
         }
         if elapsed < 60 * 60 {
             let minutes = max(1, Int(elapsed / 60))
-            return "\(minutes)m ago"
+            return "Last active \(minutes)m ago"
         }
         if elapsed < 24 * 60 * 60 {
             let hours = Int(elapsed / 3600)
-            return "\(hours)h ago"
+            return "Last active \(hours)h ago"
         }
         if elapsed < 48 * 60 * 60 {
-            return "Yesterday"
+            return "Last active yesterday"
         }
         let days = Int(elapsed / 86400)
-        return "\(days)d ago"
+        return "Last active \(days)d ago"
     }
 
     private var parsedLastSeenAt: Date? {

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -277,9 +277,17 @@ struct FriendsAndContactsSectionView: View {
             } else {
                 ForEach(friendsViewModel.friends) { friend in
                     HStack(spacing: 14) {
-                        SidebarAvatarView(avatarURL: friend.avatarURL)
-                            .frame(width: 40, height: 40)
-                            .clipShape(Circle())
+                        ZStack(alignment: .bottomTrailing) {
+                            SidebarAvatarView(avatarURL: friend.avatarURL)
+                                .frame(width: 44, height: 44)
+                                .clipShape(Circle())
+
+                            Circle()
+                                .fill(friend.isOnline ? Color.green : Color.gray)
+                                .frame(width: 12, height: 12)
+                                .overlay(Circle().strokeBorder(Color(.systemBackground), lineWidth: 2))
+                                .offset(x: 2, y: 2)
+                        }
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(friend.fullName)
@@ -287,7 +295,12 @@ struct FriendsAndContactsSectionView: View {
                                 .foregroundStyle(.primary)
                                 .lineLimit(1)
 
-                            if let voice = friend.voiceName, !voice.isEmpty {
+                            if let presence = friend.presenceText {
+                                Text(presence)
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(friend.isOnline ? .green : .gray)
+                                    .lineLimit(1)
+                            } else if let voice = friend.voiceName, !voice.isEmpty {
                                 Text(voice)
                                     .font(.system(size: 13))
                                     .foregroundStyle(.tertiary)
@@ -297,6 +310,7 @@ struct FriendsAndContactsSectionView: View {
 
                         Spacer()
                     }
+                    .padding(.vertical, 2)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Display "Last active X minutes ago" presence text for each friend in Friends & Contacts settings
- Show green dot for online, gray dot for offline on friend avatars
- Fix voice mode "responded at" label appearing on error messages

## Test plan
- [ ] Open Friends & Contacts settings and verify friends show their online status
- [ ] Test presence text displays correctly ("Online", "Last active 5m ago", etc.)
- [ ] Send a voice message that fails and verify no "responded at" label appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)