### PR TITLE
feat: Home scroll cards, settings UI redesign, and backend fixes

### DIFF
--- a/Backend/db/versions/20260215_0014_placeholder.py
+++ b/Backend/db/versions/20260215_0014_placeholder.py
@@ -1,4 +1,4 @@
-"""Placeholder for migration that was applied directly to the database.
+"""Placeholder for revisions 0012-0014 that were applied directly to the database.
 
 The production database was already upgraded to this revision. This file
 exists so Alembic can locate the revision and continue the chain.
@@ -6,8 +6,8 @@ exists so Alembic can locate the revision and continue the chain.
 from __future__ import annotations
 
 
-revision = "20260215_0011"
-down_revision = "20260203_0010"
+revision = "20260215_0014"
+down_revision = "20260215_0011"
 branch_labels = None
 depends_on = None
 

--- a/Backend/services/chat_service.py
+++ b/Backend/services/chat_service.py
@@ -1,6 +1,6 @@
 import json
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import AsyncIterator, List, Optional
@@ -245,21 +245,36 @@ class VoiceChatService:
                 )
 
                 # Use async streaming with multi-turn contents
+                chunk_count = 0
                 async for chunk in await self.client.aio.models.generate_content_stream(
                     model=self.model_name,
                     contents=contents,
                     config=config,
                 ):
+                    chunk_count += 1
                     if chunk.text:
                         yield GeminiStreamEvent(
                             type="response.output_text.delta",
                             delta=chunk.text,
                         )
+                    else:
+                        # Log why this chunk had no text (safety filter, empty candidates, etc.)
+                        finish_reason = None
+                        safety_ratings = None
+                        with suppress(Exception):
+                            if chunk.candidates:
+                                finish_reason = chunk.candidates[0].finish_reason
+                                safety_ratings = chunk.candidates[0].safety_ratings
+                        print(f"[Gemini] Empty chunk #{chunk_count}: finish_reason={finish_reason} safety={safety_ratings}")
+
+                if chunk_count == 0:
+                    print("[Gemini] WARNING: Stream returned zero chunks")
 
                 # Emit response.completed event
                 yield GeminiStreamEvent(type="response.completed")
 
             except Exception as e:
+                print(f"[Gemini] Stream error: {e}")
                 yield GeminiStreamEvent(type="response.error", error=str(e))
 
         yield event_generator()

--- a/Backend/subapps/chat_router.py
+++ b/Backend/subapps/chat_router.py
@@ -795,31 +795,42 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                     segments_list.append({"type": "text", "content": current_text_segment})
                     current_text_segment = ""
 
-                # If the AI returned an empty response, retry with reduced reasoning effort
-                # and without previous_response_id. gpt-5.2 sometimes spends its entire
-                # budget on reasoning and produces zero text output.
+                # If the AI returned an empty response, retry once.
+                # gpt-5.2 sometimes spends its entire budget on reasoning and
+                # produces zero text; Gemini can also return empty streams.
                 if (
                     not full_text_parts
                     and not segments_list
                     and not in_partner
-                    and not use_gemini
                 ):
-                    prev_id = chat_request.previous_response_id
-                    print(f"[SSE] Empty response (prev_id={'yes' if prev_id else 'no'}), retrying with reasoning=low for session {session_uuid}")
                     buffer = ""
                     in_partner = False
                     current_text_segment = ""
                     _reset_stream_debug_counters()
-                    try:
-                        async with chat_service.stream_response(
-                            messages=input_messages,
-                            previous_response_id=None,
-                            reasoning_effort="low",
-                        ) as stream:
-                            async for chunk in _consume_stream(stream):
-                                yield chunk
-                    finally:
-                        _log_stream_debug_counters("openai_empty_output_retry_low")
+                    if use_gemini:
+                        print(f"[SSE] Empty Gemini response, retrying for session {session_uuid}")
+                        try:
+                            async with voice_chat_service.stream_response(
+                                messages=input_messages,
+                                previous_response_id=None,
+                            ) as stream:
+                                async for chunk in _consume_stream(stream):
+                                    yield chunk
+                        finally:
+                            _log_stream_debug_counters("gemini_empty_output_retry")
+                    else:
+                        prev_id = chat_request.previous_response_id
+                        print(f"[SSE] Empty response (prev_id={'yes' if prev_id else 'no'}), retrying with reasoning=low for session {session_uuid}")
+                        try:
+                            async with chat_service.stream_response(
+                                messages=input_messages,
+                                previous_response_id=None,
+                                reasoning_effort="low",
+                            ) as stream:
+                                async for chunk in _consume_stream(stream):
+                                    yield chunk
+                        finally:
+                            _log_stream_debug_counters("openai_empty_output_retry_low")
                     if buffer:
                         full_text_parts.append(buffer)
                         yield f"event: token\ndata: {json.dumps(buffer)}\n\n".encode()

--- a/TalkToMe/Home/Views/HomeView.swift
+++ b/TalkToMe/Home/Views/HomeView.swift
@@ -7,23 +7,90 @@
 
 import SwiftUI
 
+struct HomeCardView: View {
+    let title: String
+    let overview: String
+    let gradientColors: [Color]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Image placeholder
+            ZStack {
+                LinearGradient(
+                    colors: gradientColors,
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                Image(systemName: "sparkles")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            .frame(height: 160)
+            .clipped()
+
+            // Text content
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color(.label))
+
+                Text(overview)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .lineLimit(2)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+        }
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color(.separator).opacity(0.3), lineWidth: 0.5)
+        )
+    }
+}
+
 struct HomeView: View {
     var body: some View {
         NavigationStack {
-            VStack(spacing: 20) {
-                Image(systemName: "house.fill")
-                    .font(.system(size: 60))
-                    .foregroundStyle(.secondary)
-                
-                Text("Home")
-                    .font(.title)
-                    .fontWeight(.semibold)
-                
-                Text("Coming soon")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+            ScrollView {
+                VStack(spacing: 16) {
+                    HomeCardView(
+                        title: "Weekly Ritual",
+                        overview: "Time for your weekly relationship ritual with David, guided by Em.",
+                        gradientColors: [Color(red: 0.55, green: 0.75, blue: 0.95), Color(red: 0.85, green: 0.65, blue: 0.45)]
+                    )
+
+                    HomeCardView(
+                        title: "Daily Check-In",
+                        overview: "A quick moment to share how you're feeling today and stay connected.",
+                        gradientColors: [Color(red: 0.70, green: 0.55, blue: 0.85), Color(red: 0.45, green: 0.65, blue: 0.90)]
+                    )
+
+                    HomeCardView(
+                        title: "Gratitude Practice",
+                        overview: "Reflect on three things you appreciate about each other this week.",
+                        gradientColors: [Color(red: 0.45, green: 0.80, blue: 0.65), Color(red: 0.35, green: 0.60, blue: 0.75)]
+                    )
+
+                    HomeCardView(
+                        title: "Conflict Resolution",
+                        overview: "Work through a recent disagreement with guided questions from Em.",
+                        gradientColors: [Color(red: 0.90, green: 0.55, blue: 0.50), Color(red: 0.75, green: 0.40, blue: 0.65)]
+                    )
+
+                    HomeCardView(
+                        title: "Dream Together",
+                        overview: "Share your hopes and plans for the future as a couple.",
+                        gradientColors: [Color(red: 0.50, green: 0.60, blue: 0.85), Color(red: 0.70, green: 0.50, blue: 0.80)]
+                    )
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(.systemBackground))
             .navigationTitle("Home")
             .navigationBarTitleDisplayMode(.large)

--- a/TalkToMe/Settings/Views/ContactSupportView.swift
+++ b/TalkToMe/Settings/Views/ContactSupportView.swift
@@ -1,136 +1,105 @@
 import SwiftUI
 
 struct ContactSupportView: View {
-    @State private var showingMailComposer = false
     @State private var isCopied: Bool = false
-    
+
+    private let supportEmail = "team.talktome@gmail.com"
+
     var body: some View {
-        VStack(spacing: 0) {
-            // Header section
-            VStack(spacing: 16) {
-                Image(systemName: "envelope.circle.fill")
-                    .font(.system(size: 60))
-                    .foregroundColor(Color(red: 0.4, green: 0.2, blue: 0.6))
-                
-                Text("Need Help?")
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-                
-                Text("We're here to help! Reach out to our support team for any questions or assistance.")
-                    .font(.body)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(nil)
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 40)
-            
-            Spacer()
-            
-            // Email section
-            VStack(spacing: 20) {
-                let accent = Color(red: 0.4, green: 0.2, blue: 0.6)
-                Button(action: {
-                    Haptics.impact(.medium)
-                    if let url = URL(string: "mailto:team.talktome@gmail.com") {
-                        UIApplication.shared.open(url)
-                    }
-                }) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "envelope.fill")
-                            .font(.system(size: 18))
-                            .foregroundColor(.white)
-                        
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Email Support")
-                                .font(.headline)
-                                .fontWeight(.medium)
-                                .foregroundColor(.white)
-                        }
-                        
-                        Spacer()
-                        
-                        Image(systemName: "arrow.up.right")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.white.opacity(0.8))
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 16)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        LinearGradient(
-                            gradient: Gradient(colors: [accent, accent.opacity(0.9)]),
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .cornerRadius(12)
-                    .shadow(color: accent.opacity(0.25), radius: 10, x: 0, y: 6)
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    Image(systemName: "envelope.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.secondary)
+
+                    Text("We're here to help")
+                        .font(.system(size: 15))
+                        .foregroundStyle(.secondary)
                 }
-                .buttonStyle(PlainButtonStyle())
-                
-                Text("Tap to open your email app")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                .padding(.top, 12)
 
-                // Copyable email card
-                MinimalCardView {
-                    HStack(spacing: 12) {
-                        IconButtonLabelView(systemName: "envelope")
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Support Email")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(.secondary)
-                            Text("team.talktome@gmail.com")
-                                .font(.system(size: 16, weight: .medium))
-                                .foregroundColor(.primary)
-                                .textSelection(.enabled)
+                // Actions card
+                VStack(spacing: 0) {
+                    // Send email row
+                    Button {
+                        Haptics.impact(.medium)
+                        if let url = URL(string: "mailto:\(supportEmail)") {
+                            UIApplication.shared.open(url)
                         }
+                    } label: {
+                        HStack(spacing: 14) {
+                            Image(systemName: "paperplane")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 30, height: 30)
 
-                        Spacer()
+                            Text("Send Email")
+                                .font(.system(size: 17))
+                                .foregroundStyle(Color(.label))
 
-                        Button(action: {
-                            UIPasteboard.general.string = "team.talktome@gmail.com"
-                            Haptics.notification(.success)
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                                withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
-                            }
-                        }) {
-                            HStack(spacing: 8) {
-                                Image(systemName: isCopied ? "checkmark.circle.fill" : "doc.on.doc")
-                                Text(isCopied ? "Copied" : "Copy")
-                            }
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(accent)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .fill(Color(.systemGray6))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 10)
-                                            .stroke(Color.primary.opacity(0.15), lineWidth: 1)
-                                    )
-                            )
+                            Spacer()
+
+                            Image(systemName: "arrow.up.right")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color(.tertiaryLabel))
                         }
-                        .buttonStyle(PlainButtonStyle())
+                        .padding(.horizontal, 16)
+                        .frame(minHeight: 44)
                     }
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        UIPasteboard.general.string = "team.talktome@gmail.com"
+                    .buttonStyle(.plain)
+
+                    Divider()
+                        .padding(.leading, 60)
+
+                    // Copy email row
+                    Button {
+                        UIPasteboard.general.string = supportEmail
                         Haptics.notification(.success)
                         withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                             withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
                         }
+                    } label: {
+                        HStack(spacing: 14) {
+                            Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 30, height: 30)
+                                .contentTransition(.symbolEffect(.replace))
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(isCopied ? "Copied!" : "Copy Email Address")
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(Color(.label))
+                                    .contentTransition(.numericText())
+
+                                Text(supportEmail)
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, 16)
+                        .frame(minHeight: 44)
                     }
+                    .buttonStyle(.plain)
                 }
+                .padding(.vertical, 6)
+                .background(Color(.secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                // Footer
+                Text("We typically respond within 24 hours.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 40)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
         }
         .navigationTitle("Contact Support")
         .navigationBarTitleDisplayMode(.inline)
@@ -139,7 +108,7 @@ struct ContactSupportView: View {
 }
 
 #Preview {
-    ContactSupportView()
+    NavigationStack {
+        ContactSupportView()
+    }
 }
-
-

--- a/TalkToMe/Settings/Views/ContactSupportView.swift
+++ b/TalkToMe/Settings/Views/ContactSupportView.swift
@@ -15,97 +15,105 @@ struct ContactSupportView: View {
                     .padding(.top, 8)
                     .padding(.bottom, 24)
 
-                // Get in Touch section
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Get in Touch")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                        .textCase(.uppercase)
-                        .padding(.horizontal, 20)
-                        .padding(.bottom, 2)
+                // Get in Touch
+                sectionHeader("Get in Touch")
 
-                    VStack(spacing: 0) {
-                        // Send email row
-                        Button {
-                            Haptics.impact(.medium)
-                            if let url = URL(string: "mailto:\(supportEmail)") {
-                                UIApplication.shared.open(url)
-                            }
-                        } label: {
-                            supportRow(
-                                icon: "paperplane",
-                                title: "Send Email",
-                                subtitle: "Opens your default mail app",
-                                trailing: AnyView(
-                                    Image(systemName: "arrow.up.right")
-                                        .font(.system(size: 14, weight: .semibold))
-                                        .foregroundStyle(Color(.tertiaryLabel))
-                                )
-                            )
+                VStack(spacing: 0) {
+                    Button {
+                        Haptics.impact(.medium)
+                        if let url = URL(string: "mailto:\(supportEmail)") {
+                            UIApplication.shared.open(url)
                         }
-                        .buttonStyle(.plain)
+                    } label: {
+                        HStack(spacing: 14) {
+                            Image(systemName: "paperplane")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 30, height: 30)
 
-                        Divider()
-                            .padding(.leading, 60)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Send Email")
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(Color(.label))
 
-                        // Copy email row
-                        Button {
-                            UIPasteboard.general.string = supportEmail
-                            Haptics.notification(.success)
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                                withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
+                                Text("Opens your default mail app")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(.secondary)
                             }
-                        } label: {
-                            supportRow(
-                                icon: isCopied ? "checkmark" : "doc.on.doc",
-                                title: isCopied ? "Copied!" : "Copy Email Address",
-                                subtitle: supportEmail,
-                                trailing: nil
-                            )
+
+                            Spacer()
+
+                            Image(systemName: "arrow.up.right")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color(.tertiaryLabel))
                         }
-                        .buttonStyle(.plain)
+                        .padding(.horizontal, 16)
+                        .frame(minHeight: 44)
                     }
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(.secondarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .buttonStyle(.plain)
+
+                    Divider()
+                        .padding(.leading, 60)
+
+                    Button {
+                        UIPasteboard.general.string = supportEmail
+                        Haptics.notification(.success)
+                        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
+                        }
+                    } label: {
+                        HStack(spacing: 14) {
+                            Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 30, height: 30)
+                                .contentTransition(.symbolEffect(.replace))
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(isCopied ? "Copied!" : "Copy Email Address")
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(Color(.label))
+                                    .contentTransition(.numericText())
+
+                                Text(supportEmail)
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, 16)
+                        .frame(minHeight: 44)
+                    }
+                    .buttonStyle(.plain)
                 }
+                .settingsCard()
                 .padding(.bottom, 20)
 
-                // Tips section
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Helpful Tips")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                        .textCase(.uppercase)
-                        .padding(.horizontal, 20)
-                        .padding(.bottom, 2)
+                // Helpful Tips
+                sectionHeader("Helpful Tips")
 
-                    VStack(spacing: 0) {
-                        tipRow("Include your device model and iOS version so we can reproduce issues faster.")
+                VStack(spacing: 0) {
+                    tipRow("Include your device model and iOS version so we can reproduce issues faster.")
 
-                        Divider()
-                            .padding(.leading, 60)
+                    Divider()
+                        .padding(.leading, 60)
 
-                        tipRow("If something looks wrong, a screenshot goes a long way.")
+                    tipRow("If something looks wrong, a screenshot goes a long way.")
 
-                        Divider()
-                            .padding(.leading, 60)
+                    Divider()
+                        .padding(.leading, 60)
 
-                        tipRow("For account or data deletion requests, use the email address linked to your account.")
-                    }
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(.secondarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-
-                    Text("We typically respond within 24 hours.")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 20)
-                        .padding(.top, 6)
+                    tipRow("For account or data deletion requests, use the email address linked to your account.")
                 }
+                .settingsCard()
+
+                Text("We typically respond within 24 hours.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 6)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
@@ -116,54 +124,38 @@ struct ContactSupportView: View {
         .background(Color(.systemGroupedBackground))
     }
 
-    private func supportRow(icon: String, title: String, subtitle: String, trailing: AnyView?) -> some View {
-        HStack(alignment: .top, spacing: 14) {
-            Image(systemName: icon)
-                .font(.system(size: 18))
-                .foregroundStyle(.secondary)
-                .frame(width: 30)
-                .padding(.top, 8)
-                .contentTransition(.symbolEffect(.replace))
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(Color(.label))
-                    .contentTransition(.numericText())
-
-                Text(subtitle)
-                    .font(.system(size: 15))
-                    .foregroundStyle(Color(.secondaryLabel))
-                    .lineSpacing(4)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            if let trailing {
-                trailing
-                    .padding(.top, 10)
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 8)
     }
 
     private func tipRow(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: 14) {
+        HStack(spacing: 14) {
             Image(systemName: "circle.fill")
                 .font(.system(size: 5))
                 .foregroundStyle(Color(.tertiaryLabel))
-                .frame(width: 30)
-                .padding(.top, 8)
+                .frame(width: 30, height: 30)
 
             Text(text)
-                .font(.system(size: 15))
+                .font(.system(size: 17))
                 .foregroundStyle(Color(.label))
-                .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .frame(minHeight: 44)
+    }
+}
+
+private extension View {
+    func settingsCard() -> some View {
+        self
+            .padding(.vertical, 6)
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
     }
 }
 

--- a/TalkToMe/Settings/Views/ContactSupportView.swift
+++ b/TalkToMe/Settings/Views/ContactSupportView.swift
@@ -15,105 +15,97 @@ struct ContactSupportView: View {
                     .padding(.top, 8)
                     .padding(.bottom, 24)
 
-                // Get in Touch
-                sectionHeader("Get in Touch")
+                // Get in Touch section
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Get in Touch")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 2)
 
-                VStack(spacing: 0) {
-                    Button {
-                        Haptics.impact(.medium)
-                        if let url = URL(string: "mailto:\(supportEmail)") {
-                            UIApplication.shared.open(url)
-                        }
-                    } label: {
-                        HStack(spacing: 14) {
-                            Image(systemName: "paperplane")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 30, height: 30)
-
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Send Email")
-                                    .font(.system(size: 17))
-                                    .foregroundStyle(Color(.label))
-
-                                Text("Opens your default mail app")
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.secondary)
+                    VStack(spacing: 0) {
+                        // Send email row
+                        Button {
+                            Haptics.impact(.medium)
+                            if let url = URL(string: "mailto:\(supportEmail)") {
+                                UIApplication.shared.open(url)
                             }
-
-                            Spacer()
-
-                            Image(systemName: "arrow.up.right")
-                                .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(Color(.tertiaryLabel))
+                        } label: {
+                            supportRow(
+                                icon: "paperplane",
+                                title: "Send Email",
+                                subtitle: "Opens your default mail app",
+                                trailing: AnyView(
+                                    Image(systemName: "arrow.up.right")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .foregroundStyle(Color(.tertiaryLabel))
+                                )
+                            )
                         }
-                        .padding(.horizontal, 16)
-                        .frame(minHeight: 44)
-                    }
-                    .buttonStyle(.plain)
+                        .buttonStyle(.plain)
 
-                    Divider()
-                        .padding(.leading, 60)
+                        Divider()
+                            .padding(.leading, 60)
 
-                    Button {
-                        UIPasteboard.general.string = supportEmail
-                        Haptics.notification(.success)
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
-                        }
-                    } label: {
-                        HStack(spacing: 14) {
-                            Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 30, height: 30)
-                                .contentTransition(.symbolEffect(.replace))
-
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(isCopied ? "Copied!" : "Copy Email Address")
-                                    .font(.system(size: 17))
-                                    .foregroundStyle(Color(.label))
-                                    .contentTransition(.numericText())
-
-                                Text(supportEmail)
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.secondary)
+                        // Copy email row
+                        Button {
+                            UIPasteboard.general.string = supportEmail
+                            Haptics.notification(.success)
+                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
                             }
-
-                            Spacer()
+                        } label: {
+                            supportRow(
+                                icon: isCopied ? "checkmark" : "doc.on.doc",
+                                title: isCopied ? "Copied!" : "Copy Email Address",
+                                subtitle: supportEmail,
+                                trailing: nil
+                            )
                         }
-                        .padding(.horizontal, 16)
-                        .frame(minHeight: 44)
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 }
-                .settingsCard()
                 .padding(.bottom, 20)
 
-                // Helpful Tips
-                sectionHeader("Helpful Tips")
+                // Tips section
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Helpful Tips")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 2)
 
-                VStack(spacing: 0) {
-                    tipRow("Include your device model and iOS version so we can reproduce issues faster.")
+                    VStack(spacing: 0) {
+                        tipRow("Include your device model and iOS version so we can reproduce issues faster.")
 
-                    Divider()
-                        .padding(.leading, 60)
+                        Divider()
+                            .padding(.leading, 60)
 
-                    tipRow("If something looks wrong, a screenshot goes a long way.")
+                        tipRow("If something looks wrong, a screenshot goes a long way.")
 
-                    Divider()
-                        .padding(.leading, 60)
+                        Divider()
+                            .padding(.leading, 60)
 
-                    tipRow("For account or data deletion requests, use the email address linked to your account.")
+                        tipRow("For account or data deletion requests, use the email address linked to your account.")
+                    }
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    Text("We typically respond within 24 hours.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 6)
                 }
-                .settingsCard()
-
-                Text("We typically respond within 24 hours.")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 20)
-                    .padding(.top, 6)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
@@ -124,38 +116,54 @@ struct ContactSupportView: View {
         .background(Color(.systemGroupedBackground))
     }
 
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title)
-            .font(.system(size: 13))
-            .foregroundStyle(.secondary)
-            .textCase(.uppercase)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 8)
+    private func supportRow(icon: String, title: String, subtitle: String, trailing: AnyView?) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 30)
+                .padding(.top, 8)
+                .contentTransition(.symbolEffect(.replace))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color(.label))
+                    .contentTransition(.numericText())
+
+                Text(subtitle)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .lineSpacing(4)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let trailing {
+                trailing
+                    .padding(.top, 10)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
     }
 
     private func tipRow(_ text: String) -> some View {
-        HStack(spacing: 14) {
+        HStack(alignment: .top, spacing: 14) {
             Image(systemName: "circle.fill")
                 .font(.system(size: 5))
                 .foregroundStyle(Color(.tertiaryLabel))
-                .frame(width: 30, height: 30)
+                .frame(width: 30)
+                .padding(.top, 8)
 
             Text(text)
-                .font(.system(size: 17))
+                .font(.system(size: 15))
                 .foregroundStyle(Color(.label))
+                .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 16)
-        .frame(minHeight: 44)
-    }
-}
-
-private extension View {
-    func settingsCard() -> some View {
-        self
-            .padding(.vertical, 6)
-            .background(Color(.secondarySystemGroupedBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .padding(.vertical, 10)
     }
 }
 

--- a/TalkToMe/Settings/Views/ContactSupportView.swift
+++ b/TalkToMe/Settings/Views/ContactSupportView.swift
@@ -7,103 +7,163 @@ struct ContactSupportView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
-                // Header
-                VStack(spacing: 8) {
-                    Image(systemName: "envelope.circle.fill")
-                        .font(.system(size: 48))
-                        .foregroundStyle(.secondary)
-
-                    Text("We're here to help")
-                        .font(.system(size: 15))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.top, 12)
-
-                // Actions card
-                VStack(spacing: 0) {
-                    // Send email row
-                    Button {
-                        Haptics.impact(.medium)
-                        if let url = URL(string: "mailto:\(supportEmail)") {
-                            UIApplication.shared.open(url)
-                        }
-                    } label: {
-                        HStack(spacing: 14) {
-                            Image(systemName: "paperplane")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 30, height: 30)
-
-                            Text("Send Email")
-                                .font(.system(size: 17))
-                                .foregroundStyle(Color(.label))
-
-                            Spacer()
-
-                            Image(systemName: "arrow.up.right")
-                                .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(Color(.tertiaryLabel))
-                        }
-                        .padding(.horizontal, 16)
-                        .frame(minHeight: 44)
-                    }
-                    .buttonStyle(.plain)
-
-                    Divider()
-                        .padding(.leading, 60)
-
-                    // Copy email row
-                    Button {
-                        UIPasteboard.general.string = supportEmail
-                        Haptics.notification(.success)
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
-                        }
-                    } label: {
-                        HStack(spacing: 14) {
-                            Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 30, height: 30)
-                                .contentTransition(.symbolEffect(.replace))
-
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(isCopied ? "Copied!" : "Copy Email Address")
-                                    .font(.system(size: 17))
-                                    .foregroundStyle(Color(.label))
-                                    .contentTransition(.numericText())
-
-                                Text(supportEmail)
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            Spacer()
-                        }
-                        .padding(.horizontal, 16)
-                        .frame(minHeight: 44)
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(.vertical, 6)
-                .background(Color(.secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-
-                // Footer
-                Text("We typically respond within 24 hours.")
-                    .font(.system(size: 13))
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Have a question, found a bug, or just want to say hi? We'd love to hear from you.")
+                    .font(.system(size: 15))
                     .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 20)
+                    .padding(.top, 8)
+                    .padding(.bottom, 24)
+
+                // Get in Touch section
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Get in Touch")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 2)
+
+                    VStack(spacing: 0) {
+                        // Send email row
+                        Button {
+                            Haptics.impact(.medium)
+                            if let url = URL(string: "mailto:\(supportEmail)") {
+                                UIApplication.shared.open(url)
+                            }
+                        } label: {
+                            supportRow(
+                                icon: "paperplane",
+                                title: "Send Email",
+                                subtitle: "Opens your default mail app",
+                                trailing: AnyView(
+                                    Image(systemName: "arrow.up.right")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .foregroundStyle(Color(.tertiaryLabel))
+                                )
+                            )
+                        }
+                        .buttonStyle(.plain)
+
+                        Divider()
+                            .padding(.leading, 60)
+
+                        // Copy email row
+                        Button {
+                            UIPasteboard.general.string = supportEmail
+                            Haptics.notification(.success)
+                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) { isCopied = false }
+                            }
+                        } label: {
+                            supportRow(
+                                icon: isCopied ? "checkmark" : "doc.on.doc",
+                                title: isCopied ? "Copied!" : "Copy Email Address",
+                                subtitle: supportEmail,
+                                trailing: nil
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+                .padding(.bottom, 20)
+
+                // Tips section
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Helpful Tips")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 2)
+
+                    VStack(spacing: 0) {
+                        tipRow("Include your device model and iOS version so we can reproduce issues faster.")
+
+                        Divider()
+                            .padding(.leading, 60)
+
+                        tipRow("If something looks wrong, a screenshot goes a long way.")
+
+                        Divider()
+                            .padding(.leading, 60)
+
+                        tipRow("For account or data deletion requests, use the email address linked to your account.")
+                    }
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    Text("We typically respond within 24 hours.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 6)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
         }
+        .scrollIndicators(.hidden)
         .navigationTitle("Contact Support")
         .navigationBarTitleDisplayMode(.inline)
         .background(Color(.systemGroupedBackground))
+    }
+
+    private func supportRow(icon: String, title: String, subtitle: String, trailing: AnyView?) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 30)
+                .padding(.top, 8)
+                .contentTransition(.symbolEffect(.replace))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color(.label))
+                    .contentTransition(.numericText())
+
+                Text(subtitle)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .lineSpacing(4)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let trailing {
+                trailing
+                    .padding(.top, 10)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func tipRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "circle.fill")
+                .font(.system(size: 5))
+                .foregroundStyle(Color(.tertiaryLabel))
+                .frame(width: 30)
+                .padding(.top, 8)
+
+            Text(text)
+                .font(.system(size: 15))
+                .foregroundStyle(Color(.label))
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
     }
 }
 

--- a/TalkToMe/Settings/Views/PrivacyPolicyView.swift
+++ b/TalkToMe/Settings/Views/PrivacyPolicyView.swift
@@ -1,86 +1,184 @@
 import SwiftUI
 
+private struct PolicySection: Identifiable {
+    let id = UUID()
+    let title: String
+    let items: [String]
+}
+
+private let policySections: [PolicySection] = [
+    PolicySection(
+        title: "Information We Collect",
+        items: [
+            "Account and Authentication: We use Supabase for authentication via Apple Sign-in, Google Sign-in, or email and password. We process your user ID, basic profile metadata from your identity provider (e.g., name, email), and session tokens stored securely in Keychain.",
+            "Profile: You can set a display name and a short bio. If you upload an avatar, the image is stored in Supabase Storage and accessed via signed URLs.",
+            "Chat: Your messages and AI-generated responses are stored so you can view history and continue conversations. This includes session titles, message previews, and any images or files you attach.",
+            "Diary: If you use the diary, your entries (including text, titles, and photos) are stored. Diary photos are uploaded to Supabase Storage.",
+            "Friends and Partner Linking: If you link with a partner using friend codes, we store relationship mappings, partner message drafts, and delivery statuses. You can assign display names to partners for a personalized experience.",
+            "Notifications: If you enable push notifications, we store your device token, platform, and bundle identifier to deliver notifications for partner messages and chat updates. You can disable this at any time in Settings.",
+            "Voice: If you use voice input, your audio is streamed to Deepgram for real-time transcription. If you enable voice playback, assistant text is sent to ElevenLabs for text-to-speech. Audio is used only to provide these features and is not stored permanently.",
+            "Local Cache: We cache profile data, chat sessions, and messages locally on your device using a local database to provide fast, offline-ready access."
+        ]
+    ),
+    PolicySection(
+        title: "How We Use Information",
+        items: [
+            "To provide and improve core features including AI chat, diary, partner messaging, voice, and notifications.",
+            "To maintain security, prevent abuse, and ensure reliable delivery of messages and notifications.",
+            "To personalize your experience, such as displaying your and your partner's avatars and names."
+        ]
+    ),
+    PolicySection(
+        title: "Third-Party Services",
+        items: [
+            "Supabase: Authentication, database, and file storage.",
+            "Deepgram: Real-time speech-to-text transcription for voice input.",
+            "ElevenLabs: Text-to-speech audio generation for voice playback.",
+            "Apple Push Notification service (APNs): Delivering push notifications to your device.",
+            "Each provider only receives data necessary to perform its service. We do not sell your personal information."
+        ]
+    ),
+    PolicySection(
+        title: "Data Retention",
+        items: [
+            "We retain your profile, chat messages, diary entries, and linking data for as long as your account is active.",
+            "You can delete individual chat sessions and diary entries from within the app.",
+            "You can request full account and data deletion by contacting support."
+        ]
+    ),
+    PolicySection(
+        title: "Your Choices",
+        items: [
+            "Notifications: Enable or disable push notifications in Settings at any time.",
+            "Partner Linking: Link or unlink a partner. Unlinking stops future partner message deliveries.",
+            "Voice: Enable or disable voice input and voice playback independently in Settings.",
+            "Profile: Update your display name, bio, and avatar at any time.",
+            "Appearance: Choose between light, dark, or system theme."
+        ]
+    ),
+    PolicySection(
+        title: "Security",
+        items: [
+            "We use HTTPS/TLS for all data in transit, signed URLs for secure file access, and Keychain for credential storage. We continually work to protect your information, though no method is completely infallible."
+        ]
+    ),
+    PolicySection(
+        title: "Children's Privacy",
+        items: [
+            "TalkToMe is not intended for children under 13. If you believe a child has provided us personal information, please contact us so we can take appropriate action."
+        ]
+    ),
+    PolicySection(
+        title: "Changes to This Policy",
+        items: [
+            "We may update this Policy to reflect changes to our practices. Continued use of the app after updates means you accept the revised Policy."
+        ]
+    ),
+    PolicySection(
+        title: "Contact Us",
+        items: [
+            "For privacy questions or requests (including data deletion), contact: sgzrov@gmail.com, muhammad84044@gmail.com"
+        ]
+    )
+]
+
 struct PrivacyPolicyView: View {
-    private let policyText: String = """
-    Privacy Policy
-    Effective: October 14, 2025
-
-    This Privacy Policy explains how TalkToMe ("we", "us", or "our") collects, uses, and shares information when you use the TalkToMe iOS application (the "App"). By using the App, you agree to this Policy.
-
-    1) Information We Collect
-    - Account and Authentication: We use Supabase for authentication (Apple/Google sign-in). We process your Supabase user ID, basic profile metadata provided by your identity provider (e.g., name, picture), and session tokens.
-    - Profile: If you choose, you can set a display name (full name) and a short bio. We store these in our database.
-    - Avatars: If you upload an avatar, the image is stored in Supabase Storage and referenced by a signed URL. We may also use provider profile images if available.
-    - Chats and Sessions: When you chat, your messages and session information (including optional generated titles and the most recent message preview) are stored so you can view history and continue conversations.
-    - Partner Linking: If you link with a partner, we store relationship mappings and, when you send partner drafts/requests, their content and status (pending/delivered/accepted) to deliver messages and maintain history for both sides.
-    - Notifications: If you enable push notifications, we store your device push token, platform (iOS), and app bundle identifier to send notifications (e.g., partner messages/requests). You can disable push at any time in Settings.
-    - Diagnostics and App Events: We may log limited technical information (e.g., request status codes, streaming state, minimal debug logs) to operate the service and troubleshoot issues. These logs are not used for advertising.
-    - Voice: If you use voice features, microphone permission is requested. Your audio may be sent to our backend for transcription using third-party AI services (e.g., OpenAI). If you enable voice playback, assistant text may be sent to a text-to-speech provider (e.g., ElevenLabs) to generate audio. Transcribed text and generated audio are used only to provide the voice features.
-
-    2) How We Use Information
-    - To provide and improve core features (chat, session history, partner linking, notifications, profile/avatars).
-    - To maintain security, prevent abuse, and ensure reliable delivery of messages and notifications.
-    - To personalize your experience (e.g., showing your and your partner’s avatars and names).
-
-    3) Sharing and Disclosure
-    - Service Providers: We use trusted service providers to operate the App, including Supabase (authentication, database, storage) and Apple Push Notification service (APNs). Providers only receive data necessary to perform their services.
-    - Legal and Safety: We may disclose information if required by law or to protect rights, safety, and the integrity of the service.
-    - We do not sell your personal information.
-
-    4) Data Retention
-    - We retain profile information, chat messages, sessions, and linking data for as long as your account is active or as needed to provide the service.
-    - You can delete individual chat sessions from within the App. You can also request account/data deletion by contacting support.
-
-    5) Your Choices
-    - Notifications: Enable or disable push notifications in Settings at any time.
-    - Partner Linking: You may link/unlink a partner. Unlinking stops new partner deliveries and removes the link mapping going forward.
-    - Profile: You can update your display name/bio and avatar.
-
-    6) Security
-    - We use industry-standard protections such as HTTPS/TLS in transit and signed URLs for avatar access. No security method is perfect, but we continually work to protect your information.
-
-    7) Children’s Privacy
-    - The App is not intended for children under 13. If you believe a child has provided us personal information, please contact us so we can take appropriate action.
-
-    8) Changes to This Policy
-    - We may update this Policy to reflect changes to our practices. Continued use of the App after updates means you accept the revised Policy.
-
-    9) Contact Us
-    - For privacy questions or requests (including deletion), contact: sgzrov@gmail.com, muhammad84044@gmail.com
-    """
-
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Privacy Policy")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Effective: February 15, 2026")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+                    .padding(.bottom, 12)
 
-                    Text(policyText)
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundColor(.primary)
-                        .multilineTextAlignment(.leading)
+                Text("This Privacy Policy explains how TalkToMe collects, uses, and shares information when you use the TalkToMe iOS application. By using the app, you agree to this Policy.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 24)
+
+                ForEach(Array(policySections.enumerated()), id: \.element.id) { index, section in
+                    PolicySectionCard(index: index + 1, section: section)
+                        .padding(.bottom, 20)
                 }
-                .padding(16)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color(.systemBackground))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.black.opacity(0.1), lineWidth: 1)
-                        )
-                )
             }
-            .padding(20)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
         }
         .scrollIndicators(.hidden)
-        .background(Color(.systemGroupedBackground).ignoresSafeArea())
+        .navigationTitle("Privacy Policy")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+private struct PolicySectionCard: View {
+    let index: Int
+    let section: PolicySection
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("\(index). \(section.title)")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 2)
+
+            VStack(spacing: 0) {
+                ForEach(Array(section.items.enumerated()), id: \.offset) { itemIndex, item in
+                    policyRow(item)
+
+                    if itemIndex < section.items.count - 1 {
+                        Divider()
+                            .padding(.leading, 60)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+    }
+
+    private func policyRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "circle.fill")
+                .font(.system(size: 5))
+                .foregroundStyle(Color(.tertiaryLabel))
+                .frame(width: 30)
+                .padding(.top, 8)
+
+            styledText(text)
+                .font(.system(size: 15))
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func styledText(_ text: String) -> Text {
+        guard let colonRange = text.range(of: ": ") else {
+            return Text(text)
+                .foregroundColor(Color(.label))
+        }
+        let label = String(text[text.startIndex..<colonRange.lowerBound])
+        let rest = String(text[colonRange.upperBound...])
+        return Text(label + ": ")
+            .fontWeight(.semibold)
+            .foregroundColor(Color(.label))
+        + Text(rest)
+            .foregroundColor(Color(.secondaryLabel))
     }
 }
 
 #Preview {
-    PrivacyPolicyView()
+    NavigationStack {
+        PrivacyPolicyView()
+    }
 }
-
-

--- a/TalkToMe/Settings/Views/PrivacyPolicyView.swift
+++ b/TalkToMe/Settings/Views/PrivacyPolicyView.swift
@@ -137,10 +137,10 @@ private struct PolicySectionCard: View {
                     }
                 }
             }
-            .padding(.vertical, 8)
+            .padding(.vertical, 6)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(.secondarySystemGroupedBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
         }
     }
 
@@ -149,17 +149,15 @@ private struct PolicySectionCard: View {
             Image(systemName: "circle.fill")
                 .font(.system(size: 5))
                 .foregroundStyle(Color(.tertiaryLabel))
-                .frame(width: 30)
-                .padding(.top, 8)
+                .frame(width: 30, height: 30)
 
             styledText(text)
-                .font(.system(size: 15))
-                .lineSpacing(4)
+                .font(.system(size: 17))
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .frame(minHeight: 44)
     }
 
     private func styledText(_ text: String) -> Text {

--- a/TalkToMe/Settings/Views/PrivacyPolicyView.swift
+++ b/TalkToMe/Settings/Views/PrivacyPolicyView.swift
@@ -137,10 +137,10 @@ private struct PolicySectionCard: View {
                     }
                 }
             }
-            .padding(.vertical, 6)
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(.secondarySystemGroupedBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         }
     }
 
@@ -149,15 +149,17 @@ private struct PolicySectionCard: View {
             Image(systemName: "circle.fill")
                 .font(.system(size: 5))
                 .foregroundStyle(Color(.tertiaryLabel))
-                .frame(width: 30, height: 30)
+                .frame(width: 30)
+                .padding(.top, 8)
 
             styledText(text)
-                .font(.system(size: 17))
+                .font(.system(size: 15))
+                .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 16)
-        .frame(minHeight: 44)
+        .padding(.vertical, 10)
     }
 
     private func styledText(_ text: String) -> Text {


### PR DESCRIPTION
## Summary
- Add scrollable Home tab with 5 placeholder cards (image, title, overview)
- Redesign Contact Support and Privacy Policy views with unified sectioned card UI — uppercase section headers, bullet-point rows, consistent spacing and alignment
- Fix Gemini empty response bug: remove `and not use_gemini` guard so voice-agent empty responses are retried automatically
- Add detailed Gemini stream logging (finish_reason, safety ratings, chunk counts)
- Fix Alembic migration chain: remove duplicate placeholder, add bridge to revision 0014

## Test plan
- [ ] Verify Home tab shows scrollable cards
- [ ] Open Contact Support and Privacy Policy — confirm consistent card styling, aligned bullets and backgrounds
- [ ] Test voice chat to confirm Gemini empty responses are retried
- [ ] Deploy backend and verify Alembic migration runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)