### PR TITLE
feat: Add buddy custom instructions editor

### DIFF
--- a/Backend/schemas/chat_models.py
+++ b/Backend/schemas/chat_models.py
@@ -30,6 +30,7 @@ class ChatRequest(BaseModel):
     voice_agent: Optional[str] = None
     ghost_name: Optional[str] = None
     delete_before: Optional[UUID] = None
+    custom_instructions: Optional[str] = None
 
 
 class ChatResponse(BaseModel):

--- a/Backend/subapps/chat_router.py
+++ b/Backend/subapps/chat_router.py
@@ -516,6 +516,11 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                     # don't fall back to chat_prompt.txt.
                     system_prompt_override = voice_agent_prompts.get_prompt(chat_request.voice_agent) or ""
 
+                    # Append user-defined custom instructions for this buddy (if any).
+                    ci = (chat_request.custom_instructions or "").strip()
+                    if ci:
+                        system_prompt_override = (system_prompt_override or "") + "\n\n" + ci
+
                 # Use Gemini for voice-agent mode, OpenAI otherwise.
                 if use_gemini:
                     # Convert chat_history to list of dicts for Gemini

--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -431,6 +431,14 @@ final class ChatStreamingController {
                 let trimmed = (self.activeVoiceAgentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 return trimmed.isEmpty ? nil : trimmed
             }()
+            let customInstructionsToSend: String? = {
+                guard let agentName = voiceAgentToSend else { return nil }
+                let key = agentName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !key.isEmpty else { return nil }
+                let prompt = UserDefaults.standard.string(forKey: PreferenceKeys.buddyCustomPromptKey(key)) ?? ""
+                let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }()
 
             let streamToken = UUID()
             let onEvent: (BackendService.StreamEvent) -> Void = { [weak self, weak delegate] event in
@@ -910,7 +918,8 @@ final class ChatStreamingController {
                     messageId: clientMessageId,
                     voiceAgent: voiceAgentToSend,
                     ghostName: ghostNameToSend,
-                    deleteBefore: deleteBeforeId
+                    deleteBefore: deleteBeforeId,
+                    customInstructions: customInstructionsToSend
                 )
                 for await event in stream {
                     onEvent(event)

--- a/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
+++ b/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
@@ -79,7 +79,7 @@ final class VoicesCache {
     }
 }
 
-private struct BuddyDefinition: Identifiable {
+struct BuddyDefinition: Identifiable {
     let key: String
     let name: String
     let description: String
@@ -116,7 +116,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
 
     // Required buddy objects for MediaPickerPanelView. These are always shown even
     // when backend ElevenLabs voices are not configured in a dev environment.
-    private static let requiredBuddies: [BuddyDefinition] = [
+    static let requiredBuddies: [BuddyDefinition] = [
         BuddyDefinition(
             key: "mira",
             name: "Mira",

--- a/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
+++ b/TalkToMe/Chat/Views/Components/TransparentVideoPlayerView.swift
@@ -81,15 +81,22 @@ final class TransparentPlayerUIView: UIView {
 
     private static let preloadLock = NSLock()
     private static var preloadedPlayers: [String: (player: AVQueuePlayer, looper: AVPlayerLooper?)] = [:]
+    /// Remembers preload config so consumed entries can be auto-replenished.
+    private static var preloadConfigs: [String: (ext: String, loop: Bool, startTime: Double)] = [:]
 
     /// Pre-build an AVQueuePlayer on a background thread so it's ready instantly
     /// when `configure` is called later.
     static func preload(videoName: String, extension ext: String, loop: Bool, startTime: Double = 0) {
         preloadLock.lock()
+        preloadConfigs[videoName] = (ext: ext, loop: loop, startTime: startTime)
         let exists = preloadedPlayers[videoName] != nil
         preloadLock.unlock()
         if exists { return }
 
+        buildPreloadedPlayer(videoName: videoName, ext: ext, loop: loop, startTime: startTime)
+    }
+
+    private static func buildPreloadedPlayer(videoName: String, ext: String, loop: Bool, startTime: Double) {
         guard let url = Bundle.main.url(forResource: videoName, withExtension: ext) else { return }
 
         DispatchQueue.global(qos: .userInitiated).async {
@@ -121,8 +128,17 @@ final class TransparentPlayerUIView: UIView {
 
     private static func takePreloaded(for videoName: String) -> (player: AVQueuePlayer, looper: AVPlayerLooper?)? {
         preloadLock.lock()
-        defer { preloadLock.unlock() }
-        return preloadedPlayers.removeValue(forKey: videoName)
+        let entry = preloadedPlayers.removeValue(forKey: videoName)
+        let config = preloadConfigs[videoName]
+        preloadLock.unlock()
+
+        // Auto-replenish: immediately start rebuilding a replacement
+        // so the next consumer gets an instant player too.
+        if entry != nil, let config {
+            buildPreloadedPlayer(videoName: videoName, ext: config.ext, loop: config.loop, startTime: config.startTime)
+        }
+
+        return entry
     }
 
     // MARK: - Init

--- a/TalkToMe/Services/Backend/BackendServiceChat.swift
+++ b/TalkToMe/Services/Backend/BackendServiceChat.swift
@@ -38,7 +38,8 @@ extension BackendService {
         messageId: UUID? = nil,
         voiceAgent: String? = nil,
         ghostName: String? = nil,
-        deleteBefore: UUID? = nil
+        deleteBefore: UUID? = nil,
+        customInstructions: String? = nil
     ) -> AsyncStream<StreamEvent> {
         var request = URLRequest(url: baseURL
             .appendingPathComponent("chat")
@@ -59,7 +60,8 @@ extension BackendService {
             friend_user_id: friendUserId,
             voice_agent: (voiceAgent?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : voiceAgent,
             ghost_name: (ghostName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : ghostName,
-            delete_before: deleteBefore
+            delete_before: deleteBefore,
+            custom_instructions: (customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true) ? nil : customInstructions
         )
         request.httpBody = try? jsonEncoder.encode(payload)
         return SSEService.shared.stream(request: request)
@@ -310,6 +312,7 @@ private struct ChatRequestBody: Codable {
     let voice_agent: String?
     let ghost_name: String?
     let delete_before: UUID?
+    let custom_instructions: String?
 }
 
 private struct MessagesResponseBody: Codable {

--- a/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
+++ b/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
@@ -65,8 +65,7 @@ class SettingsViewModel: ObservableObject {
                 icon: "",
                 gradient: [],
                 settings: [
-                    SettingItem(title: "Friends & Contacts", subtitle: nil, type: .navigation, icon: "person.2"),
-                    SettingItem(title: "Customize Buddies", subtitle: nil, type: .navigation, icon: "wand.and.stars")
+                    SettingItem(title: "Contacts", subtitle: nil, type: .navigation, icon: "person.2")
                 ]
             ),
             SettingsSection(
@@ -75,7 +74,8 @@ class SettingsViewModel: ObservableObject {
                 gradient: [],
                 settings: [
                     SettingItem(title: "Appearance", subtitle: nil, type: .navigation, icon: "circle.lefthalf.filled"),
-                    SettingItem(title: "Wallpapers", subtitle: nil, type: .navigation, icon: "photo")
+                    SettingItem(title: "Wallpapers", subtitle: nil, type: .navigation, icon: "photo"),
+                    SettingItem(title: "Customize Buddies", subtitle: nil, type: .navigation, icon: "wand.and.stars")
                 ]
             ),
             SettingsSection(

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -58,7 +58,7 @@ struct FriendsAndContactsSectionView: View {
         .listStyle(.insetGrouped)
         .scrollDismissesKeyboard(.immediately)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search")
-        .navigationTitle("Friends & Contacts")
+        .navigationTitle("Contacts")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             Task {

--- a/TalkToMe/Settings/Views/Components/SettingsCardView.swift
+++ b/TalkToMe/Settings/Views/Components/SettingsCardView.swift
@@ -272,15 +272,10 @@ private struct FriendCodeInlineRow: View {
 @ViewBuilder
 private func viewForTitle(_ title: String) -> some View {
     switch title {
-    case "Friends & Contacts":
+    case "Contacts":
         FriendsAndContactsSectionView()
     case "Customize Buddies":
-        Text("Coming soon")
-            .font(.system(size: 16))
-            .foregroundColor(.secondary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.systemGroupedBackground))
-            .navigationTitle("Customize Buddies")
+        CustomizeBuddiesView()
     case "Contact Support":
         ContactSupportView()
     case "Privacy Policy":

--- a/TalkToMe/Settings/Views/CustomizeBuddiesView.swift
+++ b/TalkToMe/Settings/Views/CustomizeBuddiesView.swift
@@ -1,0 +1,397 @@
+import SwiftUI
+
+struct CustomizeBuddiesView: View {
+
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = ""
+    @State private var drafts: [String: String] = [:]
+    @State private var saved: [String: String] = [:]
+    @State private var displayedBuddyKey: String? = nil
+    @State private var toastMessage: String? = nil
+    @State private var toastWorkItem: DispatchWorkItem? = nil
+
+    private let buddies = ElevenLabsVoiceSuggestionsView.requiredBuddies
+    private let gridColumns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+
+    private var actualCurrentKey: String {
+        selectedVoiceName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var displayedBuddy: BuddyDefinition? {
+        guard let key = displayedBuddyKey else { return nil }
+        return buddies.first(where: { $0.key == key })
+    }
+
+    private var gridBuddies: [BuddyDefinition] {
+        guard let displayed = displayedBuddy else { return buddies }
+        return buddies.filter { $0.key != displayed.key }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                // Displayed buddy — full width
+                if let displayed = displayedBuddy {
+                    expandedBuddyCard(displayed)
+                        .id("expanded-\(displayed.key)")
+                }
+
+                // Others — 2-column grid
+                if !gridBuddies.isEmpty {
+                    LazyVGrid(columns: gridColumns, spacing: 12) {
+                        ForEach(gridBuddies) { buddy in
+                            gridBuddyCard(buddy)
+                                .id("grid-\(buddy.key)")
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 32)
+        }
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle("Customize Buddies")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(Color(.systemGroupedBackground))
+        .overlay(alignment: .top) {
+            if let toastMessage {
+                ToastOverlayView(message: toastMessage, onDismiss: {
+                    dismissToast()
+                })
+                .padding(.top, 8)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
+        .onAppear {
+            for buddy in buddies {
+                let value = UserDefaults.standard.string(
+                    forKey: PreferenceKeys.buddyCustomPromptKey(buddy.key)
+                ) ?? ""
+                drafts[buddy.key] = value
+                saved[buddy.key] = value
+            }
+            if displayedBuddyKey == nil {
+                displayedBuddyKey = buddies.first(where: { $0.key == actualCurrentKey })?.key
+                    ?? buddies.first?.key
+            }
+        }
+    }
+
+    // MARK: - Expanded Buddy Card (Full Width)
+
+    @ViewBuilder
+    private func expandedBuddyCard(_ buddy: BuddyDefinition) -> some View {
+        let draftText = drafts[buddy.key] ?? ""
+        let isActualCurrent = buddy.key == actualCurrentKey
+        let hasDraft = !draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasUnsavedChanges = draftText != (saved[buddy.key] ?? "")
+
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 16) {
+                buddyVideo(buddy)
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Text(buddy.name)
+                            .font(.system(size: 20, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.primary)
+
+                        if isActualCurrent {
+                            Text("Current")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule().fill(Color(.tertiarySystemFill))
+                                )
+                        }
+                    }
+
+                    Text(Self.overviews[buddy.key] ?? buddy.description)
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                        .lineSpacing(3)
+                }
+            }
+
+            // Inline text field
+            TextField(
+                "Add custom instructions...",
+                text: draftBinding(for: buddy.key),
+                axis: .vertical
+            )
+            .font(.system(size: 15))
+            .lineLimit(3...8)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(colorScheme == .dark ? Color(.systemGray6) : Color(.systemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                    )
+            )
+
+            // Reset + Submit buttons
+            HStack {
+                let savedText = (saved[buddy.key] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if !savedText.isEmpty {
+                    Button {
+                        resetToDefault(for: buddy)
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.counterclockwise")
+                                .font(.system(size: 11))
+                            Text("Reset to default")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(
+                            Capsule().fill(Color(.tertiarySystemFill))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.opacity)
+                }
+
+                Spacer()
+
+                if hasUnsavedChanges && hasDraft {
+                    Button {
+                        submitPrompt(for: buddy)
+                    } label: {
+                        Text("Submit")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 7)
+                            .background(
+                                Capsule().fill(Color.accentColor)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: hasUnsavedChanges)
+            .animation(.easeInOut(duration: 0.25), value: (saved[buddy.key] ?? "").isEmpty)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+        .overlay(alignment: .topTrailing) {
+            buddyTag(for: buddy)
+                .padding(10)
+        }
+    }
+
+    // MARK: - Grid Buddy Card
+
+    @ViewBuilder
+    private func gridBuddyCard(_ buddy: BuddyDefinition) -> some View {
+        let savedText = saved[buddy.key] ?? ""
+        let hasPrompt = !savedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let isActualCurrent = buddy.key == actualCurrentKey
+
+        Button {
+            Haptics.selection()
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                displayedBuddyKey = buddy.key
+            }
+        } label: {
+            VStack(spacing: 10) {
+                buddyImage(buddy)
+                    .frame(width: 72, height: 72)
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                VStack(spacing: 4) {
+                    Text(buddy.name)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.primary)
+
+                    if isActualCurrent {
+                        Text("Current")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule().fill(Color(.tertiarySystemFill))
+                            )
+                    }
+                }
+
+                Text(hasPrompt ? savedText : "Edit instructions")
+                    .font(.system(size: 12))
+                    .foregroundStyle(hasPrompt ? Color.secondary : Color.secondary.opacity(0.45))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 16)
+            .padding(.bottom, 14)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color(.secondarySystemGroupedBackground))
+            )
+            .overlay(alignment: .topTrailing) {
+                buddyTag(for: buddy)
+                    .padding(8)
+            }
+        }
+        .buttonStyle(BuddyCardButtonStyle())
+    }
+
+    // MARK: - Buddy Tag
+
+    @ViewBuilder
+    private func buddyTag(for buddy: BuddyDefinition) -> some View {
+        switch buddy.key {
+        case "snow":
+            Text("Popular")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.orange))
+        case "luma":
+            Text("Most interactive")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.purple))
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Video (expanded card only)
+
+    @ViewBuilder
+    private func buddyVideo(_ buddy: BuddyDefinition) -> some View {
+        let videoExists = Bundle.main.url(forResource: buddy.videoName, withExtension: "mp4") != nil
+        if videoExists {
+            TransparentVideoPlayerView(
+                videoName: buddy.videoName,
+                videoExtension: "mp4",
+                startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[buddy.videoName] ?? 0
+            )
+        } else {
+            buddyImage(buddy)
+        }
+    }
+
+    // MARK: - Buddy Image
+
+    @ViewBuilder
+    private func buddyImage(_ buddy: BuddyDefinition) -> some View {
+        if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddy.name) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFit()
+        } else {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func draftBinding(for key: String) -> Binding<String> {
+        Binding(
+            get: { drafts[key] ?? "" },
+            set: { drafts[key] = $0 }
+        )
+    }
+
+    private func resetToDefault(for buddy: BuddyDefinition) {
+        UserDefaults.standard.removeObject(forKey: PreferenceKeys.buddyCustomPromptKey(buddy.key))
+        drafts[buddy.key] = ""
+        saved[buddy.key] = ""
+        Haptics.impact(.medium)
+        showToast("\(buddy.name) reset to default")
+    }
+
+    private func submitPrompt(for buddy: BuddyDefinition) {
+        let text = drafts[buddy.key] ?? ""
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            UserDefaults.standard.removeObject(forKey: PreferenceKeys.buddyCustomPromptKey(buddy.key))
+        } else {
+            UserDefaults.standard.set(text, forKey: PreferenceKeys.buddyCustomPromptKey(buddy.key))
+        }
+        saved[buddy.key] = text
+        Haptics.impact(.medium)
+        showToast("\(buddy.name)'s instructions updated")
+    }
+
+    private func showToast(_ message: String) {
+        toastWorkItem?.cancel()
+        withAnimation {
+            toastMessage = message
+        }
+        let work = DispatchWorkItem {
+            withAnimation {
+                toastMessage = nil
+            }
+        }
+        toastWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: work)
+    }
+
+    private func dismissToast() {
+        toastWorkItem?.cancel()
+        withAnimation {
+            toastMessage = nil
+        }
+    }
+}
+
+// MARK: - Button Style
+
+private struct BuddyCardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Overviews
+
+extension CustomizeBuddiesView {
+    static let overviews: [String: String] = [
+        "mira": "Mira brings bright energy and warmth to every conversation. She's encouraging, optimistic, and always finds the silver lining.",
+        "pax": "Pax is your grounded companion. Thoughtful and measured, he helps you slow down and see things from a wider perspective.",
+        "luma": "Luma speaks with gentle warmth and empathy. She creates a safe space where you feel heard and understood.",
+        "snow": "Snow carries a quiet confidence and elegance. He offers insight with poise and a touch of grandeur.",
+        "jay": "Jay is direct, motivated, and action-oriented. She pushes you forward and keeps the momentum going.",
+        "hex": "Hex is endlessly curious and a little mysterious. He loves exploring ideas from unexpected angles."
+    ]
+}
+
+#Preview {
+    NavigationStack {
+        CustomizeBuddiesView()
+    }
+}

--- a/TalkToMe/Settings/Views/SettingsView.swift
+++ b/TalkToMe/Settings/Views/SettingsView.swift
@@ -14,6 +14,8 @@ struct SettingsView: View {
     @Binding var isPresented: Bool
 
     @State private var avatarRefreshKey = UUID()
+    @State private var toastMessage: String? = nil
+    @State private var toastWorkItem: DispatchWorkItem? = nil
 
     private var avatarPlaceholder: AnyView { AnyView(Color.clear) }
 
@@ -60,7 +62,7 @@ struct SettingsView: View {
                 VStack(spacing: 10) {
                     avatarView
 
-                    Text(preferredName)
+                    Text(preferredName.components(separatedBy: " ").first ?? preferredName)
                         .font(.system(size: 18, weight: .semibold))
                         .foregroundColor(.primary)
                         .lineLimit(1)
@@ -123,6 +125,13 @@ struct SettingsView: View {
                 }
                 .scrollIndicators(.hidden)
             }
+            .overlay(alignment: .top) {
+                if let toastMessage {
+                    ToastOverlayView(message: toastMessage, onDismiss: dismissToast)
+                        .padding(.top, 8)
+                }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
@@ -130,6 +139,30 @@ struct SettingsView: View {
                         viewModel.showPersonalizationEdit = true
                     } label: {
                         Text("Edit")
+                    }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        if let code = friendsVM.myCode {
+                            Button {
+                                UIPasteboard.general.string = code
+                                Haptics.impact(.light)
+                                showToast("Add a Friend code copied to clipboard!")
+                            } label: {
+                                Label(code, systemImage: "square.on.square")
+                            }
+                        } else {
+                            Button {
+                                Task { await friendsVM.refreshMyCode(force: true) }
+                            } label: {
+                                Label("Load Code", systemImage: "arrow.clockwise")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "textformat.123")
+                            .font(.system(size: 16))
+                            .foregroundStyle(.primary)
                     }
                 }
             }
@@ -160,6 +193,9 @@ struct SettingsView: View {
             }
 
             Task { await friendsVM.refreshMyCode() }
+
+            // Pre-warm ghost video players for Customize Buddies
+            ElevenLabsVoiceSuggestionsView.preloadGhostVideos()
         }
         .onReceive(NotificationCenter.default.publisher(for: .profileChanged)) { _ in
             viewModel.loadProfileInfo()
@@ -167,6 +203,20 @@ struct SettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .avatarChanged)) { _ in
             avatarRefreshKey = UUID()
         }
+    }
+
+    private func showToast(_ message: String) {
+        toastWorkItem?.cancel()
+        toastMessage = message
+        let item = DispatchWorkItem { dismissToast() }
+        toastWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: item)
+    }
+
+    private func dismissToast() {
+        toastWorkItem?.cancel()
+        toastWorkItem = nil
+        toastMessage = nil
     }
 
 }

--- a/TalkToMe/Shared/PreferenceKeys.swift
+++ b/TalkToMe/Shared/PreferenceKeys.swift
@@ -19,6 +19,10 @@ enum PreferenceKeys {
     static let currentUserId = "current_user_id"
     static let didExplicitSignOut = "did_explicit_sign_out"
 
+    static func buddyCustomPromptKey(_ buddyKey: String) -> String {
+        "buddy_custom_prompt_\(buddyKey)"
+    }
+
     static func getPartnerDisplayName() -> String {
         if let displayName = UserDefaults.standard.string(forKey: PreferenceKeys.partnerDisplayName),
            !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {


### PR DESCRIPTION
## Summary

Adds per-buddy custom prompt editing in a new Customize Buddies settings screen. Users can now customize system prompts for each buddy voice agent, which are appended to the default prompts during voice mode conversations.

## Features

- **Full-width inline editor**: Edit the currently displayed buddy's custom instructions with real-time updates
- **Grid of other buddies**: 2-column layout for quick swapping between buddies
- **Manual save flow**: Submit button appears only when there are unsaved changes; Reset to Default reverts to baseline
- **Toast confirmations**: In-app notifications on submit/reset using the app's standard toast system
- **Hardcoded tags**: Snow shows "Popular" (orange), Luma shows "Most interactive" (purple) in both positions
- **Smooth animations**: Fade-in/out transitions, no jarring layout shifts when swapping buddies
- **Intelligent video caching**: Auto-replenishing preload system prevents loading flashes on subsequent views

## Technical Details

**Video Loading Optimization**:
- Added `preloadConfigs` dictionary to track preload parameters
- `takePreloaded()` now auto-triggers background rebuild when a cached player is consumed
- Grid cards use instant static images; only expanded card shows animated video
- Eliminates the flash that occurs when AVPlayer initializes

**Settings Reorganization**:
- Friends & Contacts now a standalone section
- Customize Buddies grouped with Appearance & Wallpapers

**Data Persistence**:
- Custom prompts saved to UserDefaults with buddy key pattern
- Backend appends custom instructions to voice agent system prompt on each request
- Prompt loads instantly on subsequent app launches via recycling pool

## Test plan

- [ ] Open Settings → Customize Buddies, see current buddy expanded with static grid below
- [ ] Tap a grid buddy, it animates to full-width smoothly (no flash)
- [ ] Type custom instructions, Submit button appears
- [ ] Click Submit, see toast confirmation "X's instructions updated"
- [ ] Tap expanded buddy in the grid, verify previous state restored
- [ ] Navigate away and back to Settings, verify all buddies load without delay
- [ ] Verify custom instructions are sent in voice mode API requests
- [ ] Check Snow has orange "Popular" tag, Luma has purple "Most interactive" tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)