### PR TITLE
Redesign home cards and add customization highlight

### DIFF
--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -44,6 +44,10 @@ struct ChatView: View {
                 async let dictationWarmup: Void = viewModel.voiceController.preconnectDictationSTTIfNeeded()
                 async let speakWarmup: Void = viewModel.voiceController.preconnectSpeakServicesIfNeeded()
                 _ = await (dictationWarmup, speakWarmup)
+                if sessionsViewModel.shouldStartInVoiceMode {
+                    sessionsViewModel.shouldStartInVoiceMode = false
+                    viewModel.voiceController.startSpeakMode()
+                }
             }
             .toolbar {
                 if let onBack {

--- a/TalkToMe/Chat/Views/Components/ChatSessionActionsModifier.swift
+++ b/TalkToMe/Chat/Views/Components/ChatSessionActionsModifier.swift
@@ -345,6 +345,8 @@ private struct ReportConversationFlowView: View {
     var body: some View {
         NavigationStack {
             ZStack {
+                AppTheme.background.ignoresSafeArea()
+
                 // Level 0: Category selection
                 categoryListView
 
@@ -352,7 +354,7 @@ private struct ReportConversationFlowView: View {
                 if showReasonOverlay, let category = selectedCategory {
                     reasonListView(for: category)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color(.systemBackground))
+                        .background(AppTheme.background)
                         .offset(x: reasonDragOffset)
                         .overlay(alignment: .leading) {
                             Color.clear
@@ -367,7 +369,7 @@ private struct ReportConversationFlowView: View {
                 if showDetailsOverlay, let reason = selectedReason {
                     detailsView(for: reason)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color(.systemBackground))
+                        .background(AppTheme.background)
                         .offset(x: detailsDragOffset)
                         .overlay(alignment: .leading) {
                             Color.clear

--- a/TalkToMe/ContentView.swift
+++ b/TalkToMe/ContentView.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
                     MainTabView()
                         .transition(.opacity)
                 } else {
-                    Color(.systemBackground)
+                    AppTheme.background
                         .ignoresSafeArea()
                         .transition(.opacity)
                 }

--- a/TalkToMe/Diary/Views/DiaryView.swift
+++ b/TalkToMe/Diary/Views/DiaryView.swift
@@ -1346,7 +1346,7 @@ private struct CalendarDaySheet: View {
           .padding(.bottom, 24)
         }
       }
-      .background(Color(.systemBackground))
+      .background(AppTheme.background)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .topBarTrailing) {
@@ -2025,11 +2025,11 @@ private struct DiaryNoteEditorView: View {
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
-  var body: some View {
+  private var noteEditorBase: some View {
     VStack(alignment: .leading, spacing: 10) {
       editorContent
     }
-    .background(Color(.systemBackground))
+    .background(AppTheme.background)
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.hidden, for: .navigationBar)
     .ignoresSafeArea(.keyboard, edges: .bottom)
@@ -2102,6 +2102,10 @@ private struct DiaryNoteEditorView: View {
         onFiles: { showFileImporter = true }
       )
     }
+  }
+
+  var body: some View {
+    noteEditorBase
     .fileImporter(
       isPresented: $showFileImporter, allowedContentTypes: [.item, .pdf, .plainText, .image],
       allowsMultipleSelection: true
@@ -2194,8 +2198,8 @@ private struct DiaryNoteEditorView: View {
               switch d.content {
               case .text(let s):
                 loaded.append(DiaryBlock(id: d.id, content: .text(s)))
-              case .imageStoragePath(let path):
-                let img = await DiaryService.shared.loadImage(storagePath: path)
+              case .imageURL(let url, let path):
+                let img = await DiaryService.shared.loadImageFromURL(url)
                 loaded.append(DiaryBlock(id: d.id, content: .image(img, storagePath: path)))
               }
             }
@@ -2249,7 +2253,7 @@ private struct DiaryNoteEditorView: View {
         case .text(let s):
           return .text(id: block.id, content: s)
         case .image(_, let path?) where path.isEmpty == false:
-          return .imageRemote(id: block.id, storagePath: path)
+          return .imageRemote(id: block.id, remotePath: path)
         case .image(let img?, _):
           return .imageLocal(id: block.id, image: img)
         case .image(nil, _):
@@ -2547,7 +2551,7 @@ private struct NewDiaryNoteSheet: View {
         newNoteSheetContent
       }
       .scrollDismissesKeyboard(.interactively)
-      .background(Color(.systemBackground))
+      .background(AppTheme.background)
       .toolbarBackground(.hidden, for: .navigationBar)
       .ignoresSafeArea(.keyboard, edges: .bottom)
       .toolbar {
@@ -2723,7 +2727,7 @@ private struct NewDiaryNoteSheet: View {
         case .text(let s):
           return .text(id: block.id, content: s)
         case .image(_, let path?) where path.isEmpty == false:
-          return .imageRemote(id: block.id, storagePath: path)
+          return .imageRemote(id: block.id, remotePath: path)
         case .image(let img?, _):
           return .imageLocal(id: block.id, image: img)
         case .image(nil, _):
@@ -3004,7 +3008,7 @@ private struct EditDiaryNoteSheet: View {
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
-  var body: some View {
+  private var editNoteBase: some View {
     NavigationStack {
       ScrollView {
         if isLoadingBlocksFromApi && blocks.isEmpty {
@@ -3022,7 +3026,7 @@ private struct EditDiaryNoteSheet: View {
         }
       }
       .scrollDismissesKeyboard(.interactively)
-      .background(Color(.systemBackground))
+      .background(AppTheme.background)
       .toolbarBackground(.hidden, for: .navigationBar)
       .ignoresSafeArea(.keyboard, edges: .bottom)
       .toolbar {
@@ -3118,6 +3122,10 @@ private struct EditDiaryNoteSheet: View {
         )
       }
     }
+  }
+
+  var body: some View {
+    editNoteBase
     .fileImporter(
       isPresented: $showFileImporter, allowedContentTypes: [.item, .pdf, .plainText, .image],
       allowsMultipleSelection: true
@@ -3210,8 +3218,8 @@ private struct EditDiaryNoteSheet: View {
               switch d.content {
               case .text(let s):
                 loaded.append(DiaryBlock(id: d.id, content: .text(s)))
-              case .imageStoragePath(let path):
-                let img = await DiaryService.shared.loadImage(storagePath: path)
+              case .imageURL(let url, let path):
+                let img = await DiaryService.shared.loadImageFromURL(url)
                 loaded.append(DiaryBlock(id: d.id, content: .image(img, storagePath: path)))
               }
             }
@@ -3278,7 +3286,7 @@ private struct EditDiaryNoteSheet: View {
         case .text(let s):
           return .text(id: block.id, content: s)
         case .image(_, let path?) where path.isEmpty == false:
-          return .imageRemote(id: block.id, storagePath: path)
+          return .imageRemote(id: block.id, remotePath: path)
         case .image(let img?, _):
           return .imageLocal(id: block.id, image: img)
         case .image(nil, _):

--- a/TalkToMe/Home/Views/HomeView.swift
+++ b/TalkToMe/Home/Views/HomeView.swift
@@ -10,71 +10,71 @@ import SwiftUI
 // MARK: - Feature Model
 
 private enum HomeFeature: Int, CaseIterable, Identifiable {
-  case talkToBuddy
-  case inviteFriend
-  case dailyDiary
-  case notesReminders
-  case shareStory
+  case voiceMode
+  case customize
+  case capturePhoto
+  case lateNight
+  case weekReview
 
   var id: Int { rawValue }
 
   var title: String {
     switch self {
-    case .talkToBuddy: return "Talk to AI Buddy"
-    case .inviteFriend: return "Invite a Friend"
-    case .dailyDiary: return "Daily Diary"
-    case .notesReminders: return "Notes & Reminders"
-    case .shareStory: return "Share Your Story"
+    case .voiceMode: return "Talk, Don\u{2019}t Type"
+    case .customize: return "Make It Yours"
+    case .capturePhoto: return "Capture Moments"
+    case .lateNight: return "Late Night Thoughts"
+    case .weekReview: return "Your Week in Review"
     }
   }
 
   var subtitle: String {
     switch self {
-    case .talkToBuddy:
-      return "Discuss any of your problems with AI Buddy — get advice, vent, or just talk."
-    case .inviteFriend:
-      return "Send a message from AI Buddy to anyone in your contacts."
-    case .dailyDiary:
-      return "Keep a daily diary with me. I'll help you remember and capture your day."
-    case .notesReminders:
-      return "Write down notes so you don't forget and can discuss them with me later."
-    case .shareStory:
-      return "Tell me more about yourself so we can grow together and celebrate wins."
+    case .voiceMode:
+      return "Have a real conversation using your voice. Your buddy speaks back — each one sounds different."
+    case .customize:
+      return "Wallpapers, themes, and colors — design your perfect chat space."
+    case .capturePhoto:
+      return "Add photos to your diary entries. Snap a moment, write a thought, look back anytime."
+    case .lateNight:
+      return "Can\u{2019}t sleep? Your buddy is always awake. No judgment, just good conversation at any hour."
+    case .weekReview:
+      return "Your buddy remembers everything you\u{2019}ve talked about. Ask for a recap of your week\u{2019}s highlights."
     }
   }
 
   var actionLabel: String {
     switch self {
-    case .talkToBuddy: return "Start Chat"
-    case .inviteFriend: return "Open Contacts"
-    case .dailyDiary: return "Open Diary"
-    case .notesReminders: return "Open Notes"
-    case .shareStory: return "Edit Profile"
+    case .voiceMode: return "Try Voice Mode"
+    case .customize: return "Customize"
+    case .capturePhoto: return "Open Diary"
+    case .lateNight: return "Start Chat"
+    case .weekReview: return "Open Diary"
     }
   }
 
   var iconName: String {
     switch self {
-    case .talkToBuddy: return "bubble.left.and.text.bubble.right"
-    case .inviteFriend: return "person.badge.plus"
-    case .dailyDiary: return "book.closed"
-    case .notesReminders: return "checklist"
-    case .shareStory: return "heart.text.clipboard"
+    case .voiceMode: return "waveform"
+    case .customize: return "paintpalette.fill"
+    case .capturePhoto: return "camera.fill"
+    case .lateNight: return "moon.stars.fill"
+    case .weekReview: return "calendar.badge.clock"
     }
   }
 
   var gradientColors: [Color] {
     switch self {
-    case .talkToBuddy:
-      return [Color(red: 0.26, green: 0.58, blue: 1.00), Color(red: 0.30, green: 0.78, blue: 0.95)]
-    case .inviteFriend:
+    case .voiceMode:
+      return [Color(red: 0.95, green: 0.45, blue: 0.25), Color(red: 0.98, green: 0.65, blue: 0.30)]
+    case .customize:
       return [Color(red: 0.63, green: 0.32, blue: 0.98), Color(red: 0.90, green: 0.40, blue: 0.65)]
-    case .dailyDiary:
+    case .capturePhoto:
       return [Color(red: 0.25, green: 0.72, blue: 0.68), Color(red: 0.40, green: 0.85, blue: 0.55)]
-    case .notesReminders:
-      return [Color(red: 0.95, green: 0.55, blue: 0.30), Color(red: 0.98, green: 0.75, blue: 0.35)]
-    case .shareStory:
-      return [Color(red: 0.45, green: 0.35, blue: 0.90), Color(red: 0.70, green: 0.50, blue: 0.85)]
+    case .lateNight:
+      return [Color(red: 0.20, green: 0.22, blue: 0.55), Color(red: 0.40, green: 0.30, blue: 0.75)]
+    case .weekReview:
+      return [Color(red: 0.26, green: 0.58, blue: 1.00), Color(red: 0.30, green: 0.78, blue: 0.95)]
     }
   }
 }
@@ -843,13 +843,10 @@ struct HomeView: View {
                 .foregroundStyle(.primary)
 
               if totalUnread > 0 {
-                Text("\(totalUnread)")
-                  .font(.system(size: 9, weight: .bold, design: .rounded))
-                  .foregroundStyle(.white)
-                  .frame(minWidth: 14, minHeight: 14)
-                  .background(Color.red)
-                  .clipShape(Circle())
-                  .offset(x: 6, y: -4)
+                Circle()
+                  .fill(Color.accentColor)
+                  .frame(width: 12, height: 12)
+                  .offset(x: 4, y: -4)
               }
             }
           }
@@ -859,22 +856,22 @@ struct HomeView: View {
   }
 
   private func handleCardTap(_ feature: HomeFeature) {
-    Haptics.impact(.light)
+    if feature != .customize { Haptics.impact(.light) }
     switch feature {
-    case .talkToBuddy:
+    case .voiceMode:
+      sessionsVM.shouldStartInVoiceMode = true
       onStartNewChat()
-    case .inviteFriend:
+    case .customize:
       selectedTab = .settings
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-        settingsViewModel.shouldNavigateToContacts = true
+        settingsViewModel.shouldHighlightCustomization = true
       }
-    case .dailyDiary, .notesReminders:
+    case .capturePhoto:
       selectedTab = .diary
-    case .shareStory:
-      selectedTab = .settings
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-        settingsViewModel.showPersonalizationEdit = true
-      }
+    case .lateNight:
+      onStartNewChat()
+    case .weekReview:
+      selectedTab = .diary
     }
   }
 

--- a/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
+++ b/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
@@ -11,6 +11,8 @@ class SettingsViewModel: ObservableObject {
     @Published var avatarURL: String? = nil
     @Published var showPersonalizationEdit: Bool = false
     @Published var shouldNavigateToContacts: Bool = false
+    @Published var shouldNavigateToAppearance: Bool = false
+    @Published var shouldHighlightCustomization: Bool = false
 
     private let avatarCacheManager = AvatarCacheManager.shared
 

--- a/TalkToMe/Settings/Views/AppearanceSettingsView.swift
+++ b/TalkToMe/Settings/Views/AppearanceSettingsView.swift
@@ -22,7 +22,7 @@ struct AppearanceSettingsView: View {
         .scrollIndicators(.hidden)
         .navigationTitle("Appearance")
         .navigationBarTitleDisplayMode(.inline)
-        .background(Color(.systemGroupedBackground))
+        .background(AppTheme.background)
     }
 
     // MARK: - Theme

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -56,6 +56,8 @@ struct FriendsAndContactsSectionView: View {
         .listSectionSpacing(.compact)
         .contentMargins(.top, 0)
         .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(AppTheme.background)
         .scrollDismissesKeyboard(.immediately)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search")
         .navigationTitle("Contacts")

--- a/TalkToMe/Settings/Views/Components/OnboardingFlowView.swift
+++ b/TalkToMe/Settings/Views/Components/OnboardingFlowView.swift
@@ -41,7 +41,7 @@ struct OnboardingFlowView: View {
       .animation(.easeInOut(duration: 0.5), value: showSplash)
 
       if showSplash {
-        Color.white.ignoresSafeArea()  // Use appropriate background color
+        AppTheme.background.ignoresSafeArea()
           .opacity(splashOpacity)
         Image("AppIconDisplay")
           .resizable()

--- a/TalkToMe/Settings/Views/ContactSupportView.swift
+++ b/TalkToMe/Settings/Views/ContactSupportView.swift
@@ -113,7 +113,7 @@ struct ContactSupportView: View {
         .scrollIndicators(.hidden)
         .navigationTitle("Contact Support")
         .navigationBarTitleDisplayMode(.inline)
-        .background(Color(.systemGroupedBackground))
+        .background(AppTheme.background)
     }
 
     private func supportRow(icon: String, title: String, subtitle: String, trailing: AnyView?) -> some View {

--- a/TalkToMe/Settings/Views/CustomizeBuddiesView.swift
+++ b/TalkToMe/Settings/Views/CustomizeBuddiesView.swift
@@ -54,7 +54,7 @@ struct CustomizeBuddiesView: View {
         .scrollDismissesKeyboard(.interactively)
         .navigationTitle("Customize Buddies")
         .navigationBarTitleDisplayMode(.inline)
-        .background(Color(.systemGroupedBackground))
+        .background(AppTheme.background)
         .overlay(alignment: .top) {
             if let toastMessage {
                 ToastOverlayView(message: toastMessage, onDismiss: {

--- a/TalkToMe/Settings/Views/PersonalizationEditView.swift
+++ b/TalkToMe/Settings/Views/PersonalizationEditView.swift
@@ -251,13 +251,13 @@ struct PersonalizationEditView: View {
                 }
             }
         }
-        .background(Color(.systemGray6).ignoresSafeArea())
+        .background(AppTheme.background.ignoresSafeArea())
         .animation(.spring(response: 0.45, dampingFraction: 0.9, blendDuration: 0), value: isPresented)
         .overlay(alignment: .top) {
             GeometryReader { proxy in
                 let topInset: CGFloat = proxy.safeAreaInsets.top
 
-                Color(.systemGray6)
+                AppTheme.background
                     .frame(height: topInset)
                     .ignoresSafeArea(edges: .top)
                     .overlay(

--- a/TalkToMe/Settings/Views/PrivacyPolicyView.swift
+++ b/TalkToMe/Settings/Views/PrivacyPolicyView.swift
@@ -110,7 +110,7 @@ struct PrivacyPolicyView: View {
         .scrollIndicators(.hidden)
         .navigationTitle("Privacy Policy")
         .navigationBarTitleDisplayMode(.inline)
-        .background(Color(.systemGroupedBackground))
+        .background(AppTheme.background)
     }
 }
 

--- a/TalkToMe/Settings/Views/SettingsView.swift
+++ b/TalkToMe/Settings/Views/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
   @State private var avatarRefreshKey = UUID()
   @State private var toastMessage: String? = nil
   @State private var toastWorkItem: DispatchWorkItem? = nil
+  @State private var customizationHighlightOpacity: CGFloat = 0
 
   private var avatarPlaceholder: AnyView { AnyView(Color.clear) }
 
@@ -87,7 +88,7 @@ struct SettingsView: View {
           .foregroundColor(.primary)
           .lineLimit(1)
           .frame(height: 22)
-        Text("Your Buddy")
+        Text("Buddy")
           .font(.system(size: 13, weight: .medium))
           .foregroundColor(.secondary)
           .lineLimit(1)
@@ -119,6 +120,14 @@ struct SettingsView: View {
               viewModel.handleSettingAction(for: sectionIndex, settingIndex: settingIndex)
             }
           )
+          .id(section.id)
+          .overlay {
+            if section.id == "customization" {
+              RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .strokeBorder(AppTheme.accent, lineWidth: 2)
+                .opacity(customizationHighlightOpacity)
+            }
+          }
         }
       }
     }
@@ -195,13 +204,25 @@ struct SettingsView: View {
       ZStack {
         AppTheme.background.ignoresSafeArea()
 
-        ScrollView {
-          VStack(spacing: 0) {
-            profileHeader
-            sectionsListView
+        ScrollViewReader { proxy in
+          ScrollView {
+            VStack(spacing: 0) {
+              profileHeader
+              sectionsListView
+            }
+          }
+          .scrollIndicators(.hidden)
+          .onChange(of: viewModel.shouldHighlightCustomization) { _, shouldHighlight in
+            guard shouldHighlight else { return }
+            viewModel.shouldHighlightCustomization = false
+            withAnimation(.easeOut(duration: 0.3)) {
+              proxy.scrollTo("customization", anchor: .center)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+              animateCustomizationHighlight()
+            }
           }
         }
-        .scrollIndicators(.hidden)
       }
       .overlay(alignment: .top) {
         if let toastMessage {
@@ -212,6 +233,9 @@ struct SettingsView: View {
       .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
       .navigationDestination(isPresented: $viewModel.shouldNavigateToContacts) {
         FriendsAndContactsSectionView()
+      }
+      .navigationDestination(isPresented: $viewModel.shouldNavigateToAppearance) {
+        AppearanceSettingsView()
       }
       .toolbar {
         ToolbarItem(placement: .topBarLeading) {
@@ -298,6 +322,17 @@ struct SettingsView: View {
     toastWorkItem?.cancel()
     toastWorkItem = nil
     toastMessage = nil
+  }
+
+  private func animateCustomizationHighlight() {
+    withAnimation(.easeIn(duration: 0.2)) {
+      customizationHighlightOpacity = 1.0
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+      withAnimation(.easeOut(duration: 0.3)) {
+        customizationHighlightOpacity = 0
+      }
+    }
   }
 }
 

--- a/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
+++ b/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
@@ -13,6 +13,7 @@ final class ChatSessionsViewModel: ObservableObject {
     @Published var isBootstrapping: Bool = false
     @Published var lastSessionsSyncSucceeded: Bool? = nil
     @Published var lastSessionsSyncAt: Date? = nil
+    @Published var shouldStartInVoiceMode: Bool = false
 
     private var notificationTokens: [NSObjectProtocol] = []
     private var observedUserId: String? = nil


### PR DESCRIPTION
## Summary
- Replaced 5 generic home feature cards with unique, actionable options: Talk/Don't Type (voice mode), Make It Yours (customization), Capture Moments (diary), Late Night Thoughts (chat), Your Week in Review (diary recap)
- "Talk, Don't Type" now auto-enables voice mode when tapped
- "Make It Yours" navigates to Settings and animates a single pulse highlight on the customization section
- Fixed all screens to use correct AppTheme background colors in light/dark modes (navy #0F1724 / light blue #EAF6FF)
- Late Night Thoughts and Week Review now route to different destinations for better UX

## Test plan
- [ ] Tap each home card and verify it routes to the correct destination
- [ ] Verify voice mode auto-activates when "Talk, Don't Type" is tapped
- [ ] Verify customization section briefly highlights with outline when "Make It Yours" is tapped
- [ ] Toggle dark/light mode on all screens and confirm backgrounds use AppTheme colors
- [ ] Confirm no haptic feedback fires on "Make It Yours" tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)