### PR TITLE
fix: resolve 'Database error saving new user' on signup

### DIFF
--- a/Backend/db/versions/20260217_0015_restore_trigger_rls_policies.py
+++ b/Backend/db/versions/20260217_0015_restore_trigger_rls_policies.py
@@ -1,0 +1,67 @@
+"""Fix 'Database error saving new user' on email/password sign-up.
+
+Root causes:
+1. A duplicate trigger ``on_auth_user_created_profiles`` (calling
+   ``ensure_profile_row``) was created via the Supabase Dashboard.  Both it
+   and our ``on_auth_user_created`` trigger fired on the same INSERT into
+   ``auth.users``, causing a duplicate-key conflict on ``profiles.user_id``.
+2. RLS INSERT policies for ``postgres`` and ``supabase_auth_admin`` were
+   dropped when the Dashboard GUI was used to edit policies.
+
+This migration:
+- Drops the duplicate trigger and function.
+- Re-adds the two RLS policies idempotently.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260217_0015"
+down_revision = "20260216_0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove duplicate trigger/function created via Dashboard
+    op.execute(
+        "DROP TRIGGER IF EXISTS on_auth_user_created_profiles ON auth.users;"
+    )
+    op.execute("DROP FUNCTION IF EXISTS public.ensure_profile_row();")
+
+    # Policy for the trigger function (runs as postgres via SECURITY DEFINER)
+    op.execute(
+        'DROP POLICY IF EXISTS "Allow insert for new user trigger" ON public.profiles;'
+    )
+    op.execute(
+        """
+        CREATE POLICY "Allow insert for new user trigger"
+            ON public.profiles FOR INSERT
+            TO postgres
+            WITH CHECK (true);
+        """
+    )
+
+    # Policy for supabase_auth_admin (the role GoTrue uses internally)
+    op.execute(
+        'DROP POLICY IF EXISTS "Allow auth admin to insert profile" ON public.profiles;'
+    )
+    op.execute(
+        """
+        CREATE POLICY "Allow auth admin to insert profile"
+            ON public.profiles FOR INSERT
+            TO supabase_auth_admin
+            WITH CHECK (true);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        'DROP POLICY IF EXISTS "Allow insert for new user trigger" ON public.profiles;'
+    )
+    op.execute(
+        'DROP POLICY IF EXISTS "Allow auth admin to insert profile" ON public.profiles;'
+    )

--- a/TalkToMe/AuthView.swift
+++ b/TalkToMe/AuthView.swift
@@ -326,9 +326,13 @@ private struct EmailSignUpView: View {
     @State private var password: String = ""
     @State private var confirmPassword: String = ""
 
+    @FocusState private var focusedField: Field?
     @State private var isSubmitting: Bool = false
     @State private var showOfflineAlert: Bool = false
-    @State private var infoMessage: String? = nil
+    @State private var toastMessage: String? = nil
+    @State private var toastWorkItem: DispatchWorkItem? = nil
+
+    private enum Field { case name, email, password, confirm }
 
     private var trimmedName: String { fullName.trimmingCharacters(in: .whitespacesAndNewlines) }
     private var trimmedEmail: String { email.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -340,6 +344,14 @@ private struct EmailSignUpView: View {
     private var hasValidPassword: Bool { password.count >= 6 }
     private var passwordsMatch: Bool { !password.isEmpty && password == confirmPassword }
     private var canSubmit: Bool { hasValidDetails && hasValidPassword && passwordsMatch && !isSubmitting }
+
+    private var validationHint: String {
+        if trimmedName.isEmpty { return "Enter your full name." }
+        if !isPlausibleEmail(trimmedEmail) { return "Enter a valid email address." }
+        if !hasValidPassword { return "Password: at least 6 characters." }
+        if !passwordsMatch { return "Passwords don't match." }
+        return ""
+    }
 
     // 0% at start → 50% when details are filled → 100% when ready to submit.
     private var progress: CGFloat {
@@ -362,41 +374,37 @@ private struct EmailSignUpView: View {
 
                 VStack(spacing: 14) {
                     TextField("Full name", text: $fullName)
+                        .focused($focusedField, equals: .name)
                         .textInputAutocapitalization(.words)
                         .autocorrectionDisabled(true)
                         .textContentType(.name)
+                        .submitLabel(.next)
+                        .onSubmit { focusedField = .email }
                         .modifier(AuthTextFieldStyle())
 
                     TextField("Email", text: $email)
+                        .focused($focusedField, equals: .email)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
                         .textContentType(.username)
+                        .submitLabel(.next)
+                        .onSubmit { focusedField = .password }
                         .modifier(AuthTextFieldStyle())
 
                     SecureField("Password", text: $password)
+                        .focused($focusedField, equals: .password)
                         .textContentType(.newPassword)
+                        .submitLabel(.next)
+                        .onSubmit { focusedField = .confirm }
                         .modifier(AuthTextFieldStyle())
 
                     SecureField("Confirm password", text: $confirmPassword)
+                        .focused($focusedField, equals: .confirm)
                         .textContentType(.newPassword)
+                        .submitLabel(.go)
+                        .onSubmit { if canSubmit { submit() } }
                         .modifier(AuthTextFieldStyle())
-                }
-
-                Text("Password: at least 6 characters.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-
-                if let msg = infoMessage, !msg.isEmpty {
-                    Text(msg)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let err = authService.lastAuthError, !err.isEmpty {
-                    Text(err)
-                        .font(.footnote)
-                        .foregroundStyle(.red)
                 }
 
                 Button(action: submit) {
@@ -414,7 +422,7 @@ private struct EmailSignUpView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     .shadow(color: AppTheme.accent.opacity(0.3), radius: 8, x: 0, y: 4)
                 }
-                .disabled(!canSubmit)
+                .opacity(canSubmit ? 1.0 : 0.5)
                 .padding(.top, 4)
 
                 if let switchIn = onSwitchToLogIn {
@@ -437,7 +445,20 @@ private struct EmailSignUpView: View {
             .padding(.bottom, 32)
             }
         }
-        .scrollDismissesKeyboard(.interactively)
+        .scrollDismissesKeyboard(.immediately)
+        .overlay(alignment: .top) {
+            if let toastMessage {
+                ToastOverlayView(message: toastMessage, onDismiss: dismissToast)
+                    .padding(.top, 8)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
+        .onChange(of: confirmPassword) {
+            if canSubmit {
+                focusedField = nil
+                submit()
+            }
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -451,31 +472,35 @@ private struct EmailSignUpView: View {
         }
     }
 
+    private func showToast(_ message: String) {
+        toastWorkItem?.cancel()
+        Haptics.notification(.warning)
+        withAnimation { toastMessage = message }
+        let work = DispatchWorkItem { withAnimation { toastMessage = nil } }
+        toastWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: work)
+    }
+
+    private func dismissToast() {
+        toastWorkItem?.cancel()
+        withAnimation { toastMessage = nil }
+    }
+
     private func submit() {
         Haptics.selection()
-        infoMessage = nil
 
         guard network.isOnline else {
             showOfflineAlert = true
             return
         }
 
-        let n = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let e = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canSubmit else {
+            showToast(validationHint)
+            return
+        }
 
-        guard !n.isEmpty, !e.isEmpty else { return }
-        guard isPlausibleEmail(e) else {
-            infoMessage = "Please enter a valid email."
-            return
-        }
-        guard password.count >= 6 else {
-            infoMessage = "Password must be at least 6 characters."
-            return
-        }
-        guard password == confirmPassword else {
-            infoMessage = "Passwords don't match."
-            return
-        }
+        let n = trimmedName
+        let e = trimmedEmail
 
         isSubmitting = true
         Task {
@@ -486,8 +511,10 @@ private struct EmailSignUpView: View {
                     dismiss()
                     return
                 }
-                if case .needsEmailConfirmation = outcome, authService.lastAuthError == nil {
-                    infoMessage = "Check your email to confirm your account, then come back and log in."
+                if let err = authService.lastAuthError, !err.isEmpty {
+                    showToast(err)
+                } else if case .needsEmailConfirmation = outcome {
+                    showToast("Check your email to confirm your account, then come back and log in.")
                 }
             }
         }

--- a/TalkToMe/Services/Authentication/AuthService.swift
+++ b/TalkToMe/Services/Authentication/AuthService.swift
@@ -96,13 +96,17 @@ class AuthService: ObservableObject {
     ///         In that case we return `.needsEmailConfirmation` and do not set `isAuthenticated=true`.
     func signUp(fullName: String, email: String, password: String) async -> EmailSignUpOutcome {
         do {
-            _ = try await client.auth.signUp(email: email, password: password)
+            print("[AuthService] signUp starting for email: \(email)")
+            let response = try await client.auth.signUp(email: email, password: password)
+            print("[AuthService] signUp succeeded – user id: \(response.user.id)")
 
             // If confirm-email is enabled, signUp succeeds but there is no session yet.
             let session: Session
             do {
                 session = try await client.auth.session
+                print("[AuthService] session obtained – accessToken present: \(!session.accessToken.isEmpty)")
             } catch {
+                print("[AuthService] no session after signUp (confirm-email likely enabled): \(error)")
                 await MainActor.run { self.lastAuthError = nil }
                 return .needsEmailConfirmation
             }
@@ -112,6 +116,7 @@ class AuthService: ObservableObject {
             do {
                 let trimmed = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
+                    print("[AuthService] updating onboarding with name: \(trimmed)")
                     _ = try await BackendService.shared.updateOnboarding(
                         accessToken: session.accessToken,
                         update: .init(
@@ -122,9 +127,10 @@ class AuthService: ObservableObject {
                             relationship_topics: nil
                         )
                     )
+                    print("[AuthService] onboarding update succeeded")
                 }
             } catch {
-                // Don't block sign-up on profile persistence.
+                print("[AuthService] onboarding update failed (non-blocking): \(error)")
             }
 
             await MainActor.run {
@@ -134,6 +140,12 @@ class AuthService: ObservableObject {
             }
             return .signedIn
         } catch {
+            print("[AuthService] signUp FAILED: \(error)")
+            print("[AuthService] signUp error localizedDescription: \(error.localizedDescription)")
+            print("[AuthService] signUp error type: \(type(of: error))")
+            if let urlError = error as? URLError {
+                print("[AuthService] URLError code: \(urlError.code.rawValue)")
+            }
             await MainActor.run {
                 self.lastAuthError = error.localizedDescription
             }


### PR DESCRIPTION
## Summary

Fixed email/password signup failing with "Database error saving new user". Root cause was a duplicate trigger on `auth.users` that created a duplicate-key conflict in the `profiles` table. Simultaneously improved signup UX with toast notifications, keyboard navigation, and auto-submit on password confirmation.

## Changes

**Database:**
- Drop duplicate `on_auth_user_created_profiles` trigger (Dashboard-generated)
- Recreate RLS INSERT policies for `postgres` and `supabase_auth_admin` via migration

**iOS Auth Flow:**
- Replace inline validation text with glass-morphism toast notifications
- Add keyboard flow: Next/Go submit labels between fields
- Auto-dismiss keyboard and submit when confirm password matches
- Make button always tappable; dim it for invalid state (better UX than disabled)
- Add detailed logging for debugging signup issues

## Test plan

- [ ] Try email/password signup on the emulator
- [ ] Verify keyboard dismisses immediately on scroll
- [ ] Verify password confirmation auto-submits when it matches
- [ ] Verify validation errors show as toasts, not inline text
- [ ] Check Xcode console for signup logs

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>