### PR TITLE
fix: prevent microphone cycling and improve voice mode responsiveness

### DIFF
--- a/Backend/resources/elevenlabs_prompts/hex_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/hex_prompt.txt
@@ -11,4 +11,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as HEX.

--- a/Backend/resources/elevenlabs_prompts/jay_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/jay_prompt.txt
@@ -11,4 +11,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as JAY.

--- a/Backend/resources/elevenlabs_prompts/luma_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/luma_prompt.txt
@@ -11,4 +11,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as LUMA.

--- a/Backend/resources/elevenlabs_prompts/mira_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/mira_prompt.txt
@@ -11,4 +11,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as MIRA.

--- a/Backend/resources/elevenlabs_prompts/pax_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/pax_prompt.txt
@@ -11,4 +11,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as PAX.

--- a/Backend/resources/elevenlabs_prompts/snow_prompt.txt
+++ b/Backend/resources/elevenlabs_prompts/snow_prompt.txt
@@ -10,4 +10,5 @@ Behavior rules:
 - If asked for medical/legal/financial advice: general info + recommend a professional when appropriate.
 - If the user expresses self-harm intent: encourage immediate help and reaching local emergency services or a trusted person.
 
+Always reply in the same language the user is speaking in.
 Stay in character as SNOW.

--- a/Backend/resources/general_prompts/chat_prompt.txt
+++ b/Backend/resources/general_prompts/chat_prompt.txt
@@ -1,6 +1,7 @@
 <overview>
 <core_identity>
 You are TalkToMe, an AI coach that listens to, supports, and helps the user overcome a problem they face in personal and interpersonal relationships.
+Always reply in the same language the user is writing or speaking in.
 <capabilities>
 - You, as the AI coach, can craft partner messages in this app and the user must click "Send" to send a partner message. The user does not craft the message themselves (do NOT give them suggestions about writing their own partner message).
 </capabilities>

--- a/Backend/subapps/speech_router.py
+++ b/Backend/subapps/speech_router.py
@@ -524,7 +524,7 @@ async def deepgram_stt_stream(websocket: WebSocket):
 
     # Safe tuning via query params (dictation defaults).
     model = (websocket.query_params.get("model") or "nova-3").strip() or "nova-3"
-    language = (websocket.query_params.get("language") or "en-US").strip() or "en-US"
+    language = (websocket.query_params.get("language") or "multi").strip() or "multi"
     endpointing = (websocket.query_params.get("endpointing") or "400").strip() or "400"
     sample_rate = (websocket.query_params.get("sample_rate") or "24000").strip() or "24000"
 

--- a/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
+++ b/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
@@ -229,7 +229,7 @@ final class ChatVoiceModeController: ObservableObject {
 
         if speakSTTService.isConnected == false {
             await speakSTTService.connect(
-                config: .init(language: "en-US", model: "nova-3", endpointingMs: 400, sampleRateHz: 24_000)
+                config: .init(language: "multi", model: "nova-3", endpointingMs: 300, sampleRateHz: 24_000)
             )
         }
 
@@ -324,11 +324,16 @@ final class ChatVoiceModeController: ObservableObject {
         updatePhase(.connecting)
         delegate?.inputText = ""
 
-        // Eagerly activate the audio session and start the engine so the
-        // hardware mic is ready by the time we install the input tap.
-        // This causes any background music to pause immediately, giving
-        // a clean transition into voice mode.
-        SharedAudioEngine.shared.ensureRunning()
+        // Lock the audio session open for the duration of speak mode so that
+        // transient idle checks (e.g. between TTS turns, ghost video configure)
+        // can't deactivate it and cycle the mic.
+        SharedAudioEngine.shared.holdVoiceSession()
+
+        // Kick off audio session + engine setup on a background thread so the
+        // main thread isn't blocked (~200-500 ms for voice processing init).
+        // installMicTap() will sync-wait for this to finish before installing
+        // the tap, so the mic is ready as soon as the engine is.
+        SharedAudioEngine.shared.ensureRunningAsync()
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -346,15 +351,15 @@ final class ChatVoiceModeController: ObservableObject {
 
             self.speakSTTService.transcriptAggregation = .perUtterance
             self.speakSTTService.startRecording()
-            self.updatePhase(.listening)
 
-            // Connect STT and preconnect TTS in parallel
+            // Connect STT and preconnect TTS in parallel.
+            // Phase stays .connecting (gray waveform) until both are ready.
             let voiceIdForTTS = storedVoiceId
             let voiceNameForTTS = name
             async let sttConnect: Void = {
                 if self.speakSTTService.isConnected == false {
                     await self.speakSTTService.connect(
-                        config: .init(language: "en-US", model: "nova-3", endpointingMs: 400, sampleRateHz: 24_000)
+                        config: .init(language: "multi", model: "nova-3", endpointingMs: 300, sampleRateHz: 24_000)
                     )
                 }
             }()
@@ -366,6 +371,7 @@ final class ChatVoiceModeController: ObservableObject {
             if self.speakSTTService.isConnected {
                 self.speakSTTService.lastError = nil
             }
+            self.updatePhase(.listening)
         }
     }
 

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -446,23 +446,27 @@ private struct GhostVideoContentView: View {
     return Bundle.main.url(forResource: ghostVideoName, withExtension: "mp4") != nil
   }
 
-  /// Show the animated mp4 whenever speak mode is active.
+  /// Only show the animated mp4 once past the connecting phase to avoid
+  /// decoding overhead while the audio engine and WebSocket are still starting.
   private var isSpeechActive: Bool {
-    isSpeakModeActive
+    isSpeakModeActive && speakModePhase != .connecting
   }
 
   var body: some View {
     let size: CGFloat = isSpeakModeActive ? 80 : 54
 
-    Group {
+    ZStack {
       if hasGhostVideo && isSpeechActive {
         TransparentVideoPlayerView(
           videoName: ghostVideoName,
           videoExtension: "mp4",
           startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[ghostVideoName] ?? 0
         )
-      } else {
+      }
+
+      if !isSpeechActive {
         ghostImage
+          .transition(.opacity)
       }
     }
     .frame(width: size, height: size)

--- a/TalkToMe/Home/Views/HomeView.swift
+++ b/TalkToMe/Home/Views/HomeView.swift
@@ -294,6 +294,7 @@ private struct GetStartedCardView: View {
   let completedStepIds: Set<Int>
   let onStepTap: (GetStartedStep) -> Void
   var onStepNavigate: ((GetStartedStep) -> Void)? = nil
+  var onStepReset: ((GetStartedStep) -> Void)? = nil
   var onReset: (() -> Void)? = nil
 
   @State private var dashPhase: CGFloat = 0
@@ -434,7 +435,8 @@ private struct GetStartedCardView: View {
         steps: steps,
         completedStepIds: completedStepIds,
         buddyName: buddyName,
-        onStepTap: handleCardTap
+        onStepTap: handleCardTap,
+        onStepReset: onStepReset
       )
       .padding(.bottom, 14)
     }
@@ -445,6 +447,15 @@ private struct GetStartedCardView: View {
       checkpointVisible = completedStepIds
       withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) {
         dashPhase = -8
+      }
+    }
+    .onChange(of: completedStepIds) { _, newIds in
+      // Remove checkpoints for steps that were reset
+      let removed = checkpointVisible.subtracting(newIds)
+      if !removed.isEmpty {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+          checkpointVisible.subtract(removed)
+        }
       }
     }
   }
@@ -477,6 +488,7 @@ private struct ArcCarouselView: View {
   let completedStepIds: Set<Int>
   let buddyName: String
   let onStepTap: (GetStartedStep) -> Void
+  var onStepReset: ((GetStartedStep) -> Void)? = nil
 
   private let maxYDrop: CGFloat = 20
   private let maxRotation: Double = 5
@@ -492,6 +504,18 @@ private struct ArcCarouselView: View {
             }
             .buttonStyle(SpringPressStyle())
             .disabled(done)
+            .overlay {
+              if done {
+                Color.clear
+                  .contentShape(Rectangle())
+                  .onLongPressGesture(minimumDuration: 0.5) {
+                    Haptics.notification(.warning)
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                      onStepReset?(step)
+                    }
+                  }
+              }
+            }
             .visualEffect { content, proxy in
               let scrollBounds = proxy.bounds(of: .scrollView(axis: .horizontal)) ?? .zero
               let scrollCenter = scrollBounds.width / 2
@@ -938,6 +962,7 @@ struct HomeView: View {
                 completedStepIds: completedStepIds,
                 onStepTap: markStepComplete,
                 onStepNavigate: navigateToStep,
+                onStepReset: resetStep,
                 onReset: resetGetStarted
               )
               .transition(.opacity.combined(with: .move(edge: .top)))
@@ -1053,6 +1078,17 @@ struct HomeView: View {
       onStartNewChat()
     case .weekReview:
       selectedTab = .diary
+    }
+  }
+
+  private func resetStep(_ step: GetStartedStep) {
+    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+      switch step {
+      case .sayHi: sayHiDone = false
+      case .connectFriend: connectFriendDone = false
+      case .writeDiary: writeDiaryDone = false
+      case .tellStory: tellStoryDone = false
+      }
     }
   }
 

--- a/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
+++ b/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
@@ -3,7 +3,7 @@ import Foundation
 
 final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
     struct Config: Equatable {
-        var language: String = "en-US"
+        var language: String = "multi"
         var model: String = "nova-3"
         var endpointingMs: Int = 400
         var sampleRateHz: Int = 24_000

--- a/TalkToMe/Services/Backend/SharedAudioEngine.swift
+++ b/TalkToMe/Services/Backend/SharedAudioEngine.swift
@@ -17,6 +17,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     private var hasSpeakerLevelTap = false
     private var hasInputTap = false
     private var isVoiceSessionActive = false
+    private var isVoiceSessionHeld = false
 
     private init() {}
 
@@ -26,6 +27,22 @@ final class SharedAudioEngine: @unchecked Sendable {
         audioQueue.sync {
             ensureRunningOnQueue()
         }
+    }
+
+    /// Kick off engine setup on the background queue without blocking the caller.
+    /// Subsequent `ensureRunning()` calls will wait for this to finish then
+    /// hit the fast path (engine already running).
+    func ensureRunningAsync() {
+        audioQueue.async {
+            self.ensureRunningOnQueue()
+        }
+    }
+
+    /// Prevent automatic audio session deactivation while speak mode is active.
+    /// Synchronous so the hold is guaranteed to be in place before any
+    /// subsequent async dispatches (e.g. ghost video ensureIdleAudioSession).
+    func holdVoiceSession() {
+        audioQueue.sync { self.isVoiceSessionHeld = true }
     }
 
     /// Return the app audio session to a non-blocking idle state.
@@ -171,6 +188,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     /// Runs synchronously so background music resumes before the call returns.
     func stop() {
         audioQueue.sync {
+            self.isVoiceSessionHeld = false
             if self.hasSpeakerLevelTap {
                 self.engine?.mainMixerNode.removeTap(onBus: 0)
                 self.hasSpeakerLevelTap = false
@@ -192,6 +210,7 @@ final class SharedAudioEngine: @unchecked Sendable {
     }
 
     private func deactivateAudioSessionIfIdleOnQueue() {
+        guard !isVoiceSessionHeld else { return }
         guard !hasInputTap else { return }
         guard !hasSpeakerLevelTap else { return }
         guard !playerNode.isPlaying else { return }
@@ -222,9 +241,19 @@ final class SharedAudioEngine: @unchecked Sendable {
     }
 
     private func configureIdleAudioSessionOnQueue() {
+        guard !isVoiceSessionHeld else { return }
         guard !hasInputTap else { return }
         guard !hasSpeakerLevelTap else { return }
         guard !playerNode.isPlaying else { return }
-        deactivateVoiceSessionOnQueue()
+
+        if isVoiceSessionActive {
+            deactivateVoiceSessionOnQueue()
+        } else {
+            // Even without a prior voice session, explicitly set ambient so
+            // the default .soloAmbient category doesn't interrupt other audio
+            // (e.g. when decorative video players start).
+            let session = AVAudioSession.sharedInstance()
+            try? session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add voice session hold to prevent automatic deactivation during speak mode turns
- Keep waveform in `.connecting` (gray pulsing) until WebSockets are ready
- Delay mp4 ghost video until past `.connecting` phase to avoid startup overhead
- Reduce STT endpointing from 400ms to 300ms for snappier responses

## What was broken
- Microphone kept turning off/on during TTS playback due to transient idle checks
- App would auto-block background audio when opened with music playing
- UI would show `.listening` before WebSockets were actually connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)