### PR TITLE
feat: update chat empty state with buddy branding and overview

### DIFF
--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -55,6 +55,7 @@ struct ChatView: View {
                     }
                 }
             }
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 if let onBack {
                     ToolbarItem(placement: .topBarLeading) {

--- a/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
+++ b/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
@@ -20,6 +20,8 @@ struct BuddyHeaderView: View {
         "mira": "Bright and uplifting",
         "pax": "Calm and wise",
         "luma": "Soft and warm",
+        "jay": "Bold and driven",
+        "hex": "Arcane and curious",
     ]
 
     private var buddyDescription: String {

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -325,7 +325,7 @@ struct MessagesListView: View {
     @ViewBuilder
     private var chatEmptyState: some View {
         VStack(spacing: 24) {
-            // Static domino of ghost buddies
+            // Static domino of ghost buddy cards
             Button {
                 Haptics.impact(.light)
                 NotificationCenter.default.post(name: .openMediaPanel, object: nil)
@@ -347,13 +347,13 @@ struct MessagesListView: View {
             .buttonStyle(GhostCardPressStyle())
             .frame(height: 120)
 
-            VStack(spacing: 14) {
+            VStack(spacing: 8) {
                 Button {
                     Haptics.impact(.light)
                     NotificationCenter.default.post(name: .openMediaPanel, object: nil)
                 } label: {
                     HStack(spacing: 4) {
-                        Text("Choose your ghost")
+                        Text("Choose Your Buddy")
                             .font(.system(size: 17, weight: .bold))
                         Image(systemName: "chevron.right")
                             .font(.system(size: 12, weight: .semibold))
@@ -361,6 +361,12 @@ struct MessagesListView: View {
                     .foregroundStyle(.primary)
                 }
                 .buttonStyle(.plain)
+
+                Text("Vent about anything, get advice, or have your buddy draft messages to send to friends.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Renamed "Choose your ghost" to "Choose Your Buddy" in the chat empty state
- Added a compact subtitle: "Vent about anything, get advice, or have your buddy draft messages to send to friends."
- Added buddy descriptions for jay and hex
- Set inline navigation bar title display mode

## Test plan
- [ ] Open a new chat and verify the empty state shows "Choose Your Buddy" with the subtitle below
- [ ] Confirm tapping the buddy cards / title still opens the media panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)