### PR TITLE
fix: eliminate flash and jitter when opening existing chats

### DIFF
--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -32,6 +32,7 @@ struct MessagesListView: View {
     @State private var enforcedOffsetY: CGFloat? = nil
     @State private var scrollToTopTargetId: UUID? = nil
     @State private var isAnimatingToTop: Bool = false
+    @State private var isContentReady: Bool = false
 
     private var messages: [ChatMessage] { chatViewModel.messages }
     private var initialJumpToken: Int { chatViewModel.initialJumpToken }
@@ -228,10 +229,13 @@ struct MessagesListView: View {
                 }, onAttach: { scrollView in
                     underlyingScrollView = scrollView
                     scrollView.clipsToBounds = true
-                    if !messages.isEmpty {
+                    if chatViewModel.sessionId == nil {
+                        isContentReady = true
+                    } else if !messages.isEmpty {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                             scrollView.layoutIfNeeded()
                             scrollToBottomUIKit(scrollView, animated: false)
+                            if !isContentReady { isContentReady = true }
                         }
                     }
                 })
@@ -296,6 +300,7 @@ struct MessagesListView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 sv.layoutIfNeeded()
                 scrollToBottomUIKit(sv, animated: false)
+                if !isContentReady { isContentReady = true }
             }
         }
         .onChange(of: isInputFocused, initial: false) { _, focused in
@@ -306,6 +311,17 @@ struct MessagesListView: View {
                 scrollToBottomUIKit(sv, animated: true)
             }
         }
+        .onChange(of: chatViewModel.isLoadingHistory, initial: false) { _, loading in
+            if !loading && !isContentReady {
+                if let sv = underlyingScrollView, !messages.isEmpty {
+                    sv.layoutIfNeeded()
+                    scrollToBottomUIKit(sv, animated: false)
+                }
+                isContentReady = true
+            }
+        }
+        .opacity(isContentReady ? 1 : 0)
+        .animation(nil, value: isContentReady)
         .onChange(of: chatViewModel.pendingOutgoingUserMessageId, initial: false) { _, newId in
             guard let id = newId else { return }
             chatViewModel.pendingOutgoingUserMessageId = nil


### PR DESCRIPTION
## Summary
- Hide ScrollView content until scroll-to-bottom completes
- Three paths reveal based on session state: new chat (immediate), cached messages (50ms), cold cache (async)
- Prevents empty state flash and scroll jitter when opening existing chats

## Test plan
- Open an existing chat → should appear at bottom with no flash
- Open a new chat → should show ghost cards immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)