### PR TITLE
Fix voice chat race conditions and TTS cutoff

### DIFF
--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -301,6 +301,13 @@ final class ChatStreamingController {
 
         cancelCurrentStream()
 
+        // Create and register the stream token synchronously so the old
+        // stream's onFinish handler sees a non-nil currentStreamToken that
+        // differs from its captured value, preventing it from clobbering
+        // the new placeholder's currentAssistantMessageId.
+        let streamToken = UUID()
+        currentStreamToken = streamToken
+
         let isVoiceModeMessage = activeVoiceAgentName != nil
         let placeholderMessage = ChatMessage.text("", isFromUser: false, isFromVoiceMode: isVoiceModeMessage)
         delegate.messages.append(placeholderMessage)
@@ -440,7 +447,6 @@ final class ChatStreamingController {
                 return trimmed.isEmpty ? nil : trimmed
             }()
 
-            let streamToken = UUID()
             let onEvent: (BackendService.StreamEvent) -> Void = { [weak self, weak delegate] event in
                 guard let self = self, let delegate = delegate else { return }
                 switch event {
@@ -681,7 +687,7 @@ final class ChatStreamingController {
                             self.typingDelayTask?.cancel()
                             delegate.isAssistantTyping = false
                         }
-                        let currentGhostName = UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName)
+                        let currentGhostName = self.ghostNameBySession[sid]
                         currentSegments.append(.partnerMessage(text: text, ghostName: currentGhostName))
                         if sid == delegate.sessionId {
                             var newMessages = delegate.messages
@@ -786,11 +792,9 @@ final class ChatStreamingController {
                             delegate.thinkingTextDone = false
                             self.isStreaming = false
                             delegate.streamingDidFinish()
-                        }
-                        Task { @MainActor in self.currentAssistantMessageId = nil }
-                        Task { @MainActor in self.currentStreamingSessionId = nil }
-                        if let sid = delegate.sessionId {
-                            Task { @MainActor in
+                            self.currentAssistantMessageId = nil
+                            self.currentStreamingSessionId = nil
+                            if let sid = delegate.sessionId {
                                 delegate.setCachedMessages(delegate.messages, for: sid)
                             }
                         }
@@ -889,17 +893,27 @@ final class ChatStreamingController {
                 }
             }
 
+            let capturedStreamToken = streamToken
             let onFinish: () -> Void = { [weak self, weak delegate] in
                 Task { @MainActor in
+                    guard let self else { return }
+                    // If a newer stream is already active, this is a stale
+                    // onFinish from a cancelled stream — do nothing.
+                    if self.currentStreamToken != nil && self.currentStreamToken != capturedStreamToken {
+                        return
+                    }
                     delegate?.isLoading = false
                     delegate?.isAssistantTyping = false
-                    self?.isStreaming = false
-                    self?.currentAssistantMessageId = nil
-                    self?.onCacheUpdate?()
+                    self.isStreaming = false
+                    self.currentAssistantMessageId = nil
+                    self.onCacheUpdate?()
                 }
             }
 
-            let ghostNameToSend = UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName)
+            let ghostNameToSend: String? = {
+                let trimmed = (self.activeVoiceAgentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }()
             let cleanedGhostName = ghostNameToSend?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !cleanedGhostName.isEmpty {
                 self.ghostNameBySession[localSessionIdForSend] = cleanedGhostName
@@ -938,7 +952,6 @@ final class ChatStreamingController {
 
             await MainActor.run {
                 self.currentStreamTask = task
-                self.currentStreamToken = streamToken
             }
         }
     }
@@ -950,6 +963,7 @@ final class ChatStreamingController {
         delegate?.thinkingText = ""
         delegate?.thinkingTextDone = false
         isStreaming = false
+        currentAssistantMessageId = nil
     }
 
     func regenerateResponse(forAssistantMessageId assistantMessageId: UUID) {

--- a/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
+++ b/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
@@ -49,6 +49,10 @@ final class ChatVoiceModeController: ObservableObject {
     private var pendingSpeakAutoSendTask: Task<Void, Never>?
     private var isSpeakComposerLocked: Bool = false
     private var speakModeVoiceName: String?
+    private var speakModeVoiceId: String?
+
+    var capturedVoiceId: String? { speakModeVoiceId }
+    var capturedVoiceName: String? { speakModeVoiceName }
 
     init() {}
 
@@ -148,14 +152,11 @@ final class ChatVoiceModeController: ObservableObject {
                 guard let self else { return }
                 guard self.isSpeakModeActive else { return }
                 if speaking {
-                    // If TTS is playing and user starts speaking, cancel TTS immediately.
-                    // Don't wait for the final transcript — stop the audio now so the
-                    // user hears silence while they talk. The message will be sent later
-                    // when lastFinalUtterance fires.
-                    if self.elevenLabsStreamingTTS.isSpeaking || self.isStreamingCheck() {
-                        self.streamingController?.stopGeneration()
-                        self.elevenLabsStreamingTTS.cancel()
-                    }
+                    // During TTS playback, do NOT cancel TTS from interim
+                    // transcripts — AEC leakage can sustain isUserSpeaking
+                    // with the ghost's own speech. Only the lastFinalUtterance
+                    // handler (with its 8-char guard) triggers barge-in.
+                    // Just update the visual phase here.
                     self.updatePhase(.listening)
                 }
             }
@@ -315,6 +316,7 @@ final class ChatVoiceModeController: ObservableObject {
             name = (cached.first(where: { $0.voice_id == storedVoiceId })?.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         }
         speakModeVoiceName = name
+        speakModeVoiceId = storedVoiceId
         streamingController?.activeVoiceAgentName = name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : name
 
         isSpeakModeActive = true
@@ -398,6 +400,7 @@ final class ChatVoiceModeController: ObservableObject {
         elevenLabsStreamingTTS.cancel()
 
         speakModeVoiceName = nil
+        speakModeVoiceId = nil
 
         speakSTTService.stopRecording()
         speakSTTService.disconnect()

--- a/TalkToMe/Chat/ViewModels/ChatViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatViewModel.swift
@@ -390,9 +390,9 @@ extension ChatViewModel: ChatStreamingDelegate {
             return
         }
 
-        let voiceId = (UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceId) ?? "")
+        let voiceId = (voiceController.capturedVoiceId ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let voiceName = (UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName) ?? "")
+        let voiceName = (voiceController.capturedVoiceName ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !voiceId.isEmpty else { return }
 

--- a/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
+++ b/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
@@ -17,6 +17,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
     private var config: Config = .init()
     private var voiceId: String?
     private var voiceName: String?
+    private var connectedVoiceId: String?
     private let audioQueue = DispatchQueue(label: "talktome.elevenlabs.tts.audio")
     private let wsSendQueue = DispatchQueue(label: "talktome.elevenlabs.tts.wsSend")
 
@@ -43,7 +44,14 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
 
     @MainActor
     func preconnect(voiceId: String, voiceName: String? = nil, config: Config = .init()) async {
-        guard !isConnected else { return }
+        if isConnected {
+            if voiceId == connectedVoiceId { return }
+            stopKeepAlive()
+            wsTask?.cancel(with: .goingAway, reason: nil)
+            wsTask = nil
+            isConnected = false
+            connectedVoiceId = nil
+        }
         self.config = config
         self.voiceId = voiceId
         self.voiceName = voiceName
@@ -75,13 +83,21 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         }
 
         if isConnected {
-            self.flushPendingTextImmediately()
-            if self.pendingFinish {
-                self.pendingFinish = false
+            if voiceId != connectedVoiceId {
+                stopKeepAlive()
+                wsTask?.cancel(with: .goingAway, reason: nil)
+                wsTask = nil
+                isConnected = false
+                connectedVoiceId = nil
+            } else {
                 self.flushPendingTextImmediately()
-                self.sendEvent(["type": "end"])
+                if self.pendingFinish {
+                    self.pendingFinish = false
+                    self.flushPendingTextImmediately()
+                    self.sendEvent(["type": "end"])
+                }
+                return
             }
-            return
         }
 
         guard let token = await AuthService.shared.getAccessToken() else {
@@ -145,6 +161,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         wsTask?.cancel(with: .goingAway, reason: nil)
         wsTask = nil
         isConnected = false
+        connectedVoiceId = nil
         stopPlayback()
     }
 
@@ -199,6 +216,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         }
         wsTask?.cancel(with: .goingAway, reason: nil)
         wsTask = task
+        connectedVoiceId = voiceId
     }
 
     private func receiveLoop() {


### PR DESCRIPTION
## Summary

Fixes three critical voice chat bugs that were degrading speak-mode UX:

- **Ghost voices mix-up**: Different ghosts would speak with the same voice due to WebSocket reuse without voice ID validation
- **Missing chat text**: Audio played but text didn't appear in chat when barging in rapidly
- **TTS cutoff from echo**: Hardware AEC leakage was misinterpreted as user speech, cutting off TTS mid-sentence

## Changes

**Voice mix-up fix**: Added `connectedVoiceId` tracking to `ElevenLabsStreamingTTSService`. Both `start()` and `preconnect()` verify the requested voice matches the WebSocket voice — if not, tear down and reconnect. Voice ID/name now captured at speak mode start to prevent divergence.

**Missing text fix**: Fixed race condition where old stream's `onFinish` handler clobbered the new stream's `currentAssistantMessageId`. Stream token now created synchronously before placeholder creation. `onFinish` guards with captured token to skip stale cleanup. `.done` handler consolidated into single task to eliminate race.

**TTS cutoff fix**: `isUserSpeaking` handler now only updates visual phase during TTS — never cancels. Barge-in triggered exclusively by `lastFinalUtterance` handler (with 8-char guard), the reliable Deepgram signal.

## Test plan

- Switch between ghosts in speak mode; verify each uses correct voice
- Barge-in rapidly during ghost response; verify text appears in chat
- Let ghost respond fully without interruption; verify no cutoff from ambient noise/echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)