### PR TITLE
refactor: remove chat bg imagery and improve connection status

### DIFF
--- a/TalkToMe/Chat/Views/ChatScreenView.swift
+++ b/TalkToMe/Chat/Views/ChatScreenView.swift
@@ -4,18 +4,13 @@ struct ChatScreenView: View {
 
   @ObservedObject var chatViewModel: ChatViewModel
 
-  @AppStorage(PreferenceKeys.chatWallpaperType) private var wallpaperType: String = "default"
-  @AppStorage(PreferenceKeys.chatWallpaperValue) private var wallpaperValue: String = ""
   @AppStorage(PreferenceKeys.dictationEnabled) private var dictationEnabled: Bool = false
-  @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = "mira"
 
   let onSend: () -> Void
   let isInputFocused: FocusState<Bool>.Binding
 
   @State private var toastMessage: String? = nil
   @State private var toastWorkItem: DispatchWorkItem? = nil
-  @State private var wallpaperPhoto: UIImage? = nil
-
   private var inputAreaHeight: CGFloat {
     chatViewModel.pendingAttachments.isEmpty ? 68 : 220
   }
@@ -101,26 +96,10 @@ struct ChatScreenView: View {
       }
     }
     .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
-    .task(id: wallpaperLoadKey) {
-      await refreshWallpaperPhoto()
-    }
     .background {
-      ZStack {
-        chatBackground
-          .ignoresSafeArea()
-
-        if wallpaperType == "default" {
-          ChatFloatingGhostBackdrop(ghostName: selectedVoiceName)
-            .opacity(0.42)
-            .ignoresSafeArea()
-            .allowsHitTesting(false)
-        }
-      }
+      AppTheme.background
+        .ignoresSafeArea()
     }
-  }
-
-  private var wallpaperLoadKey: String {
-    "\(wallpaperType)::\(wallpaperValue)"
   }
 
   private func showDictationToast() {
@@ -138,142 +117,6 @@ struct ChatScreenView: View {
     toastMessage = nil
   }
 
-  @ViewBuilder
-  private var chatBackground: some View {
-    switch wallpaperType {
-    case "gradient":
-      if let preset = wallpaperPresets.first(where: { $0.id == wallpaperValue }) {
-        preset.gradient
-      } else {
-        AppTheme.background
-      }
-    case "color":
-      WallpapersSettingsView.colorFromHex(wallpaperValue)
-    case "photo":
-      if let image = wallpaperPhoto {
-        Image(uiImage: image)
-          .resizable()
-          .scaledToFill()
-      } else {
-        AppTheme.background
-      }
-    default:
-      AppTheme.background
-    }
-  }
-
-  @MainActor
-  private func refreshWallpaperPhoto() async {
-    guard wallpaperType == "photo", !wallpaperValue.isEmpty else {
-      wallpaperPhoto = nil
-      return
-    }
-
-    let requestedKey = wallpaperLoadKey
-    let filename = wallpaperValue
-    let data = await Task.detached(priority: .utility) {
-      let url = WallpapersSettingsView.wallpaperFileURL(filename: filename)
-      return try? Data(contentsOf: url)
-    }.value
-
-    guard requestedKey == wallpaperLoadKey else { return }
-    wallpaperPhoto = data.flatMap(UIImage.init(data:))
-  }
-
-}
-
-private struct ChatFloatingGhostBackdrop: View {
-  let ghostName: String
-
-  var body: some View {
-    if let ghostImage = resolvedGhostImage {
-      GeometryReader { proxy in
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
-          let time = context.date.timeIntervalSinceReferenceDate
-          let size = proxy.size
-
-          ZStack {
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.20,
-              baseY: 0.24,
-              xAmplitude: size.width * 0.10,
-              yAmplitude: size.height * 0.08,
-              driftX: 0.16,
-              driftY: 0.13,
-              phase: 0.3,
-              widthFactor: 0.95,
-              blur: 42,
-              opacity: 0.22
-            )
-
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.76,
-              baseY: 0.72,
-              xAmplitude: size.width * 0.12,
-              yAmplitude: size.height * 0.09,
-              driftX: 0.12,
-              driftY: 0.15,
-              phase: 2.2,
-              widthFactor: 0.82,
-              blur: 36,
-              opacity: 0.20
-            )
-          }
-        }
-      }
-      .clipped()
-    }
-  }
-
-  private var resolvedGhostImage: UIImage? {
-    if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: ghostName) {
-      return image
-    }
-    for buddy in ElevenLabsVoiceSuggestionsView.requiredBuddies {
-      if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddy.key) {
-        return image
-      }
-    }
-    return nil
-  }
-
-  private func ghostLayer(
-    image: UIImage,
-    size: CGSize,
-    time: TimeInterval,
-    baseX: CGFloat,
-    baseY: CGFloat,
-    xAmplitude: CGFloat,
-    yAmplitude: CGFloat,
-    driftX: Double,
-    driftY: Double,
-    phase: Double,
-    widthFactor: CGFloat,
-    blur: CGFloat,
-    opacity: Double
-  ) -> some View {
-    let x = size.width * baseX + CGFloat(sin(time * driftX + phase)) * xAmplitude
-    let y = size.height * baseY + CGFloat(cos(time * driftY + phase)) * yAmplitude
-    let pulse = 1 + CGFloat(sin(time * 0.1 + phase)) * 0.04
-
-    return Image(uiImage: image)
-      .resizable()
-      .scaledToFit()
-      .frame(width: max(size.width * widthFactor, 220))
-      .scaleEffect(pulse)
-      .saturation(0)
-      .contrast(1.18)
-      .brightness(-0.14)
-      .opacity(opacity)
-      .blur(radius: blur)
-      .position(x: x, y: y)
-  }
 }
 
 #Preview("Chat Screen") {

--- a/TalkToMe/Diary/Views/DiaryView.swift
+++ b/TalkToMe/Diary/Views/DiaryView.swift
@@ -73,7 +73,7 @@ struct DiaryView: View {
       .navigationTitle("")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
-        ToolbarItem(placement: .topBarTrailing) {
+        ToolbarItem(placement: .topBarLeading) {
           Button("Edit") {
             Haptics.impact(.light)
             showDiaryEditor = true
@@ -374,7 +374,7 @@ private struct DiaryHeroCardView: View {
           .foregroundStyle(.white.opacity(0.94))
       }
       .padding(.horizontal, 18)
-      .padding(.top, 92)
+      .padding(.top, 136)
       .padding(.bottom, 22)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }

--- a/TalkToMe/MainAppView.swift
+++ b/TalkToMe/MainAppView.swift
@@ -10,14 +10,12 @@ import SwiftUI
 struct MainAppView: View {
     let onOpenChat: (UUID) -> Void
     let onStartNewChat: () -> Void
-    var searchText: String = ""
     var hideHeader: Bool = false
 
     var body: some View {
         SidebarView(
             onOpenChat: onOpenChat,
             onStartNewChat: onStartNewChat,
-            searchText: searchText,
             hideHeader: hideHeader
         )
     }

--- a/TalkToMe/MainTabView.swift
+++ b/TalkToMe/MainTabView.swift
@@ -12,7 +12,6 @@ enum AppTab: Hashable {
   case diary
   case chat
   case settings
-  case search
 }
 
 struct MainTabView: View {
@@ -22,8 +21,6 @@ struct MainTabView: View {
   @State private var selectedTab: AppTab = .home
   @State private var showChat: Bool = false
   @State private var chatDragOffset: CGFloat = 0
-  @State private var searchString: String = ""
-
   private let dismissThreshold: CGFloat = 100
 
   private func openChat(sessionId: UUID?) {
@@ -79,18 +76,6 @@ struct MainTabView: View {
 
         Tab("Settings", systemImage: "gearshape", value: .settings) {
           SettingsTabWrapper()
-        }
-
-        Tab(value: .search, role: .search) {
-          NavigationStack {
-            MainAppView(
-              onOpenChat: { sid in openChat(sessionId: sid) },
-              onStartNewChat: { openChat(sessionId: nil) },
-              searchText: searchString
-            )
-            .searchable(text: $searchString)
-            .navigationBarHidden(true)
-          }
         }
       }
 

--- a/TalkToMe/Settings/Views/SettingsView.swift
+++ b/TalkToMe/Settings/Views/SettingsView.swift
@@ -282,6 +282,15 @@ struct SettingsView: View {
       }
       .toolbar {
         ToolbarItem(placement: .topBarLeading) {
+          Button {
+            Haptics.impact(.light)
+            viewModel.showPersonalizationEdit = true
+          } label: {
+            Text("Edit")
+          }
+        }
+
+        ToolbarItem(placement: .topBarTrailing) {
           Menu {
             if let code = friendsVM.myCode {
               Button {
@@ -302,15 +311,6 @@ struct SettingsView: View {
             Image(systemName: "textformat.123")
               .font(.system(size: 16))
               .foregroundStyle(.primary)
-          }
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-          Button {
-            Haptics.impact(.light)
-            viewModel.showPersonalizationEdit = true
-          } label: {
-            Text("Edit")
           }
         }
       }

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -8,9 +8,9 @@ struct SidebarView: View {
 
   let onOpenChat: (UUID) -> Void
   let onStartNewChat: () -> Void
-  var searchText: String = ""
   var hideHeader: Bool = false
-  @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = "mira"
+
+  @State private var searchText: String = ""
 
   private struct SessionSection: Identifiable {
     let id: String
@@ -80,14 +80,6 @@ struct SidebarView: View {
     return keys.isEmpty ? ["mira", "pax", "luma", "snow", "jay", "hex"] : keys
   }
 
-  private var backgroundGhostName: String {
-    let trimmed = selectedVoiceName.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmed.isEmpty {
-      return mascotKeys.first ?? "mira"
-    }
-    return trimmed
-  }
-
   @State private var renameText: String = ""
   @State private var renameTargetId: UUID? = nil
 
@@ -104,67 +96,68 @@ struct SidebarView: View {
   @MainActor
   var body: some View {
     GeometryReader { geometry in
-      ZStack(alignment: .top) {
-        sidebarBackground
-          .ignoresSafeArea()
+      ScrollView {
+        let availableWidth = geometry.size.width
 
-        ScrollView {
-          let availableWidth = geometry.size.width
+        VStack(alignment: .leading, spacing: 12) {
+          if let error = sessionsViewModel.sessionsLoadError,
+            !error.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          {
+            statusCard(
+              title: "Couldn't refresh chats",
+              subtitle: error,
+              icon: "wifi.exclamationmark",
+              tint: .orange
+            )
+          }
 
-          VStack(alignment: .leading, spacing: 12) {
-            if !hideHeader {
-              Color.clear.frame(height: 108)
-            }
+          if filteredSessions.isEmpty {
+            loadingState
+          } else {
+            ForEach(groupedSessions) { section in
+              Text(section.title)
+                .font(.system(size: 12, weight: .semibold))
+                .textCase(.uppercase)
+                .tracking(0.55)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.top, 2)
 
-            if let error = sessionsViewModel.sessionsLoadError,
-              !error.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            {
-              statusCard(
-                title: "Couldn't refresh chats",
-                subtitle: error,
-                icon: "wifi.exclamationmark",
-                tint: .orange
-              )
-            }
-
-            if sessionsViewModel.isLoadingSessions && sessionsViewModel.sessions.isEmpty {
-              loadingState
-            } else if filteredSessions.isEmpty {
-              emptyState
-            } else {
-              ForEach(groupedSessions) { section in
-                Text(section.title)
-                  .font(.system(size: 12, weight: .semibold))
-                  .textCase(.uppercase)
-                  .tracking(0.55)
-                  .foregroundStyle(.secondary)
-                  .padding(.horizontal, 4)
-                  .padding(.top, 2)
-
-                LazyVStack(spacing: 10) {
-                  ForEach(section.sessions, id: \.id) { session in
-                    sessionRow(session, availableWidth: availableWidth)
-                  }
+              LazyVStack(spacing: 10) {
+                ForEach(section.sessions, id: \.id) { session in
+                  sessionRow(session, availableWidth: availableWidth)
                 }
               }
             }
           }
-          .padding(.horizontal, 18)
-          .padding(.top, 6)
-          .padding(.bottom, 24)
         }
-        .scrollIndicators(.hidden)
-        .refreshable { await sessionsViewModel.refreshSessions() }
-
-        if !hideHeader {
-          headerBar
-            .padding(.horizontal, 16)
-            .padding(.top, 6)
-        }
+        .padding(.horizontal, 18)
+        .padding(.top, 6)
+        .padding(.bottom, 24)
       }
+      .scrollIndicators(.hidden)
+      .refreshable { await sessionsViewModel.refreshSessions() }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background {
+      sidebarBackground
+        .ignoresSafeArea()
+    }
     .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .topBarLeading) {
+        EditButton()
+      }
+
+      ToolbarItem(placement: .principal) {
+        ConnectionStatusPillView()
+      }
+
+      ToolbarItemGroup(placement: .topBarTrailing) {
+        headerNewChatButton
+        headerTalkNowButton
+      }
+    }
     .onAppear {
       Task {
         await sessionsViewModel.ensureProfilePictureCached()
@@ -180,63 +173,15 @@ struct SidebarView: View {
     }
   }
 
-  // MARK: - Header Bar
-
-  private var headerBar: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      HStack(alignment: .center, spacing: 12) {
-        VStack(alignment: .leading, spacing: 2) {
-          Text("Chat History")
-            .font(.system(size: 31, weight: .bold, design: .rounded))
-            .foregroundStyle(.primary)
-            .lineLimit(1)
-
-          Text("Jump back into any conversation")
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
-
-        Spacer(minLength: 0)
-
-        HStack(spacing: 10) {
-          headerNewChatButton
-          headerTalkNowButton
-        }
-      }
-
-      HStack(spacing: 8) {
-        ConnectionStatusPillView()
-        Spacer(minLength: 0)
-        Text(chatCountLabel)
-          .font(.system(size: 12, weight: .semibold))
-          .foregroundStyle(.secondary)
-          .padding(.horizontal, 10)
-          .padding(.vertical, 6)
-          .background(Color(.secondarySystemBackground).opacity(0.82), in: Capsule())
-      }
-    }
-    .padding(.horizontal, 4)
-    .padding(.vertical, 6)
-  }
-
   private var headerNewChatButton: some View {
-    let label = Image(systemName: "plus.bubble.fill")
-      .font(.system(size: 18, weight: .semibold))
-      .frame(width: 38, height: 38)
-      .contentShape(Circle())
-
-    return Button(action: {
+    Button(action: {
       Haptics.impact(.light)
       onStartNewChat()
     }) {
-      if #available(iOS 26.0, *) {
-        label
-          .glassEffect(.regular.interactive(), in: .circle)
-      } else {
-        label
-          .background(Color(.secondarySystemBackground), in: Circle())
-      }
+      Image(systemName: "plus")
+        .font(.system(size: 18, weight: .semibold))
+        .frame(width: 38, height: 38)
+        .contentShape(Circle())
     }
     .buttonStyle(.plain)
     .accessibilityLabel("New Chat")
@@ -247,17 +192,14 @@ struct SidebarView: View {
       Haptics.impact(.light)
       startVoiceChat()
     }) {
-      ToolbarGhostTalkModeIcon(ghostName: backgroundGhostName)
-        .frame(width: 58, height: 58)
+      Image(systemName: "waveform")
+        .font(.system(size: 18, weight: .semibold))
+        .frame(width: 38, height: 38)
+        .contentShape(Circle())
     }
     .buttonStyle(.plain)
     .accessibilityLabel("Talk Now")
     .accessibilityHint("Start a new voice chat")
-  }
-
-  private var chatCountLabel: String {
-    let count = filteredSessions.count
-    return count == 1 ? "1 chat" : "\(count) chats"
   }
 
   // MARK: - Session Row
@@ -383,34 +325,7 @@ struct SidebarView: View {
   }
 
   private var sidebarBackground: some View {
-    ZStack {
-      LinearGradient(
-        colors: [
-          AppTheme.background,
-          AppTheme.brand.opacity(0.12),
-          AppTheme.background,
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-      )
-
-      FloatingGhostSilhouettesView(ghostName: backgroundGhostName)
-        .opacity(1.0)
-        .allowsHitTesting(false)
-
-      LinearGradient(
-        colors: [
-          Color.white.opacity(0.08),
-          Color.clear,
-          Color.black.opacity(0.08),
-        ],
-        startPoint: .top,
-        endPoint: .bottom
-      )
-      .blendMode(.softLight)
-
-      FloatingGhostSpritesView(primaryGhostName: backgroundGhostName)
-    }
+    AppTheme.background
   }
 
   @ViewBuilder
@@ -489,59 +404,6 @@ struct SidebarView: View {
     }
   }
 
-  private var emptyState: some View {
-    let isSearching = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    let shape = RoundedRectangle(cornerRadius: 18, style: .continuous)
-
-    return VStack(spacing: 12) {
-      Image(systemName: isSearching ? "magnifyingglass.circle" : "bubble.left.and.bubble.right")
-        .font(.system(size: 32, weight: .medium))
-        .foregroundStyle(.secondary)
-
-      Text(isSearching ? "No matching chats" : "No chats yet")
-        .font(.system(size: 18, weight: .semibold))
-        .foregroundStyle(.primary)
-
-      Text(
-        isSearching
-          ? "Try a different title or message keyword."
-          : "Start a new chat and it will appear here."
-      )
-      .font(.system(size: 14))
-      .foregroundStyle(.secondary)
-      .multilineTextAlignment(.center)
-      .padding(.horizontal, 14)
-
-      if !isSearching {
-        Button {
-          Haptics.impact(.light)
-          onStartNewChat()
-        } label: {
-          Label("Start New Chat", systemImage: "plus.bubble.fill")
-            .font(.system(size: 14, weight: .semibold))
-            .padding(.horizontal, 14)
-            .padding(.vertical, 9)
-            .background(AppTheme.accent, in: Capsule())
-            .foregroundStyle(.white)
-        }
-        .buttonStyle(.plain)
-      }
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 26)
-    .padding(.horizontal, 14)
-    .background {
-      if #available(iOS 26.0, *) {
-        Color.clear.glassEffect(.regular, in: shape)
-      } else {
-        shape.fill(AppTheme.surface.opacity(0.76))
-      }
-    }
-    .overlay {
-      shape.stroke(Color(.separator).opacity(0.2), lineWidth: 0.5)
-    }
-    .padding(.top, 6)
-  }
 
   // MARK: - Rename Sheet
 
@@ -667,388 +529,6 @@ struct SidebarView: View {
     let iso2 = ISO8601DateFormatter()
     iso2.formatOptions = [.withInternetDateTime]
     return iso1.date(from: raw) ?? iso2.date(from: raw)
-  }
-}
-
-private struct FloatingGhostSpritesView: View {
-  @Environment(\.colorScheme) private var colorScheme
-  let primaryGhostName: String
-
-  private var ghostImages: [UIImage] {
-    var images: [UIImage] = ElevenLabsVoiceSuggestionsView.requiredBuddies.compactMap { buddy in
-      ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddy.key)
-    }
-    if let selected = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: primaryGhostName) {
-      if images.contains(where: { $0 === selected }) == false {
-        images.insert(selected, at: 0)
-      }
-    }
-    return images
-  }
-
-  var body: some View {
-    if !ghostImages.isEmpty {
-      GeometryReader { proxy in
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
-          let time = context.date.timeIntervalSinceReferenceDate
-          let size = proxy.size
-
-          ZStack {
-            spriteLayer(
-              image: ghostImages[0 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.12,
-              baseY: 0.14,
-              xAmplitude: size.width * 0.10,
-              yAmplitude: size.height * 0.08,
-              speedX: 0.20,
-              speedY: 0.14,
-              phase: 0.25,
-              widthFactor: 0.16,
-              opacity: 0.22,
-              blur: 1.2
-            )
-
-            spriteLayer(
-              image: ghostImages[1 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.84,
-              baseY: 0.16,
-              xAmplitude: size.width * 0.12,
-              yAmplitude: size.height * 0.08,
-              speedX: 0.17,
-              speedY: 0.11,
-              phase: 1.15,
-              widthFactor: 0.15,
-              opacity: 0.20,
-              blur: 1.0,
-              mirror: true
-            )
-
-            spriteLayer(
-              image: ghostImages[2 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.30,
-              baseY: 0.38,
-              xAmplitude: size.width * 0.13,
-              yAmplitude: size.height * 0.09,
-              speedX: 0.15,
-              speedY: 0.12,
-              phase: 2.30,
-              widthFactor: 0.14,
-              opacity: 0.19,
-              blur: 1.6
-            )
-
-            spriteLayer(
-              image: ghostImages[3 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.72,
-              baseY: 0.44,
-              xAmplitude: size.width * 0.14,
-              yAmplitude: size.height * 0.10,
-              speedX: 0.16,
-              speedY: 0.18,
-              phase: 2.95,
-              widthFactor: 0.14,
-              opacity: 0.20,
-              blur: 1.4,
-              mirror: true
-            )
-
-            spriteLayer(
-              image: ghostImages[4 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.16,
-              baseY: 0.70,
-              xAmplitude: size.width * 0.12,
-              yAmplitude: size.height * 0.10,
-              speedX: 0.18,
-              speedY: 0.13,
-              phase: 3.60,
-              widthFactor: 0.15,
-              opacity: 0.21,
-              blur: 1.1
-            )
-
-            spriteLayer(
-              image: ghostImages[5 % ghostImages.count],
-              canvas: size,
-              time: time,
-              baseX: 0.83,
-              baseY: 0.72,
-              xAmplitude: size.width * 0.14,
-              yAmplitude: size.height * 0.11,
-              speedX: 0.14,
-              speedY: 0.17,
-              phase: 4.10,
-              widthFactor: 0.16,
-              opacity: 0.18,
-              blur: 1.8,
-              mirror: true
-            )
-          }
-        }
-      }
-      .allowsHitTesting(false)
-      .clipped()
-    }
-  }
-
-  @ViewBuilder
-  private func spriteLayer(
-    image: UIImage,
-    canvas: CGSize,
-    time: TimeInterval,
-    baseX: CGFloat,
-    baseY: CGFloat,
-    xAmplitude: CGFloat,
-    yAmplitude: CGFloat,
-    speedX: Double,
-    speedY: Double,
-    phase: Double,
-    widthFactor: CGFloat,
-    opacity: Double,
-    blur: CGFloat,
-    mirror: Bool = false
-  ) -> some View {
-    let x = canvas.width * baseX + CGFloat(sin(time * speedX + phase)) * xAmplitude
-    let y = canvas.height * baseY + CGFloat(cos(time * speedY + phase)) * yAmplitude
-    let pulse = 1 + CGFloat(sin(time * 0.18 + phase)) * 0.07
-    let angle = Double(sin(time * (speedX + speedY) * 0.5 + phase)) * 8
-    let spriteWidth = max(canvas.width * widthFactor, 84)
-    let baseOpacity = max(opacity, 0.18)
-    let glowOpacity = baseOpacity * (colorScheme == .dark ? 0.96 : 0.78)
-    let coreOpacity = min(1.0, baseOpacity * (colorScheme == .dark ? 1.75 : 1.48))
-
-    ZStack {
-      Image(uiImage: image)
-        .resizable()
-        .scaledToFit()
-        .frame(width: spriteWidth)
-        .scaleEffect(x: mirror ? -1 : 1, y: 1)
-        .scaleEffect(pulse)
-        .rotationEffect(.degrees(angle))
-        .saturation(0)
-        .brightness(colorScheme == .dark ? 0.28 : 0.18)
-        .opacity(glowOpacity)
-        .blur(radius: blur + 10)
-        .blendMode(colorScheme == .dark ? .screen : .plusLighter)
-
-      Image(uiImage: image)
-        .resizable()
-        .scaledToFit()
-        .frame(width: spriteWidth)
-        .scaleEffect(x: mirror ? -1 : 1, y: 1)
-        .scaleEffect(pulse)
-        .rotationEffect(.degrees(angle))
-        .saturation(0)
-        .contrast(1.20)
-        .brightness(colorScheme == .dark ? 0.10 : 0.05)
-        .opacity(coreOpacity)
-        .blur(radius: blur + 1.2)
-    }
-    .position(x: x, y: y)
-    .allowsHitTesting(false)
-  }
-}
-
-private struct FloatingGhostSilhouettesView: View {
-  let ghostName: String
-
-  var body: some View {
-    if let ghostImage = resolvedGhostImage {
-      GeometryReader { proxy in
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
-          let time = context.date.timeIntervalSinceReferenceDate
-          let size = proxy.size
-
-          ZStack {
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.10,
-              baseY: 0.16,
-              xAmplitude: size.width * 0.16,
-              yAmplitude: size.height * 0.13,
-              driftX: 0.19,
-              driftY: 0.15,
-              phase: 0.35,
-              widthFactor: 0.94,
-              blur: 42,
-              opacity: 0.26,
-              rotation: 8
-            )
-
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.90,
-              baseY: 0.43,
-              xAmplitude: size.width * 0.18,
-              yAmplitude: size.height * 0.11,
-              driftX: 0.16,
-              driftY: 0.20,
-              phase: 1.85,
-              widthFactor: 0.80,
-              blur: 35,
-              opacity: 0.22,
-              rotation: 7,
-              mirror: true
-            )
-
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.55,
-              baseY: 0.60,
-              xAmplitude: size.width * 0.09,
-              yAmplitude: size.height * 0.08,
-              driftX: 0.14,
-              driftY: 0.12,
-              phase: 2.9,
-              widthFactor: 0.70,
-              blur: 34,
-              opacity: 0.18,
-              rotation: 5
-            )
-
-            ghostLayer(
-              image: ghostImage,
-              size: size,
-              time: time,
-              baseX: 0.24,
-              baseY: 0.86,
-              xAmplitude: size.width * 0.14,
-              yAmplitude: size.height * 0.12,
-              driftX: 0.21,
-              driftY: 0.14,
-              phase: 3.75,
-              widthFactor: 1.02,
-              blur: 48,
-              opacity: 0.16,
-              rotation: 9
-            )
-          }
-        }
-      }
-      .clipped()
-    }
-  }
-
-  private var resolvedGhostImage: UIImage? {
-    if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: ghostName) {
-      return image
-    }
-    for buddy in ElevenLabsVoiceSuggestionsView.requiredBuddies {
-      if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddy.key) {
-        return image
-      }
-    }
-    return nil
-  }
-
-  @ViewBuilder
-  private func ghostLayer(
-    image: UIImage,
-    size: CGSize,
-    time: TimeInterval,
-    baseX: CGFloat,
-    baseY: CGFloat,
-    xAmplitude: CGFloat,
-    yAmplitude: CGFloat,
-    driftX: Double,
-    driftY: Double,
-    phase: Double,
-    widthFactor: CGFloat,
-    blur: CGFloat,
-    opacity: Double,
-    rotation: Double,
-    mirror: Bool = false
-  ) -> some View {
-    let x = size.width * baseX + CGFloat(sin(time * driftX + phase)) * xAmplitude
-    let y = size.height * baseY + CGFloat(cos(time * driftY + phase)) * yAmplitude
-    let angle = CGFloat(sin(time * (driftX + driftY) * 0.5 + phase)) * CGFloat(rotation)
-    let pulse = 1 + CGFloat(sin(time * 0.11 + phase)) * 0.05
-
-    Image(uiImage: image)
-      .resizable()
-      .scaledToFit()
-      .frame(width: max(size.width * widthFactor, 220))
-      .scaleEffect(x: mirror ? -1 : 1, y: 1)
-      .scaleEffect(pulse)
-      .saturation(0)
-      .contrast(1.22)
-      .brightness(-0.16)
-      .opacity(opacity)
-      .blur(radius: blur)
-      .rotationEffect(.degrees(Double(angle)))
-      .position(x: x, y: y)
-  }
-}
-
-private struct ToolbarGhostTalkModeIcon: View {
-  let ghostName: String
-
-  private var ghostVideoName: String {
-    ElevenLabsVoiceSuggestionsView.ghostVideoName(for: ghostName)
-      ?? ghostName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
-  private var hasGhostVideo: Bool {
-    guard !ghostVideoName.isEmpty else { return false }
-    return Bundle.main.url(forResource: ghostVideoName, withExtension: "mp4") != nil
-  }
-
-  var body: some View {
-    TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
-      let time = context.date.timeIntervalSinceReferenceDate
-      let bob = CGFloat(sin(time * 2.1)) * 2.0
-      let tilt = Double(sin(time * 1.45)) * 4.0
-      let pulse = 1 + CGFloat(sin(time * 2.4)) * 0.04
-
-      ZStack {
-        if hasGhostVideo {
-          TransparentVideoPlayerView(
-            videoName: ghostVideoName,
-            videoExtension: "mp4",
-            startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[ghostVideoName] ?? 0
-          )
-          .scaleEffect(pulse)
-        } else if let image = resolvedGhostImage {
-          Image(uiImage: image)
-            .resizable()
-            .scaledToFit()
-            .scaleEffect(pulse)
-        } else {
-          Image(systemName: "waveform")
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(.primary)
-        }
-      }
-      .offset(y: bob)
-      .rotationEffect(.degrees(tilt))
-    }
-  }
-
-  private var resolvedGhostImage: UIImage? {
-    if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: ghostName) {
-      return image
-    }
-    for buddy in ElevenLabsVoiceSuggestionsView.requiredBuddies {
-      if let image = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddy.key) {
-        return image
-      }
-    }
-    return nil
   }
 }
 
@@ -1375,8 +855,14 @@ private struct ConnectionStatusPillView: View {
   }
 
   private var pillStatus: PillStatus? {
+    // During bootstrap, drive the flow: Connecting → Updating → done
+    if sessionsViewModel.isBootstrapping {
+      if sessionsViewModel.isLoadingSessions { return .updating }
+      return .connecting
+    }
+
+    // After bootstrap, surface network / sync issues
     if networkMonitor.pathStatus != .satisfied { return .waitingForNetwork }
-    if authService.isCheckingAuth { return .connecting }
     if isReconnectUpdating { return .updating }
 
     let now = Date()
@@ -1388,7 +874,6 @@ private struct ConnectionStatusPillView: View {
         <= recentFailureWindowSeconds)
     if sessionsFailedRecently { return .connecting }
 
-    if sessionsViewModel.isBootstrapping && sessionsViewModel.sessions.isEmpty { return .updating }
     if sessionsViewModel.isLoadingSessions && sessionsViewModel.sessions.isEmpty {
       return .updating
     }
@@ -1397,29 +882,29 @@ private struct ConnectionStatusPillView: View {
 
   @ViewBuilder
   private func pillView(_ status: PillStatus) -> some View {
-    if #available(iOS 26.0, *) {
-      let capsule = Capsule(style: .continuous)
-      HStack(spacing: 6) {
-        switch status {
-        case .waitingForNetwork:
-          Image(systemName: "wifi.slash")
-            .font(.system(size: 11, weight: .regular))
-          Text("Waiting for network...")
-            .font(.system(size: 12, weight: .regular))
-        case .connecting:
-          ProgressView()
-            .controlSize(.mini)
-          Text("Connecting...")
-            .font(.system(size: 12, weight: .regular))
-        case .updating:
-          ProgressView()
-          Text("Updating...")
-            .font(.system(size: 12, weight: .regular))
-        }
+    let capsule = Capsule(style: .continuous)
+    let content = HStack(spacing: 6) {
+      ProgressView()
+        .controlSize(.mini)
+      switch status {
+      case .waitingForNetwork:
+        Text("Waiting for network...")
+          .font(.system(size: 12, weight: .regular))
+      case .connecting:
+        Text("Connecting...")
+          .font(.system(size: 12, weight: .regular))
+      case .updating:
+        Text("Updating...")
+          .font(.system(size: 12, weight: .regular))
       }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 6)
-      .glassEffect(.regular.interactive(), in: capsule)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+
+    if #available(iOS 26.0, *) {
+      content.glassEffect(.regular.interactive(), in: capsule)
+    } else {
+      content.background(.ultraThinMaterial, in: capsule)
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove floating ghost decorations and wallpaper system from sidebar
- Restore ConnectionStatusPillView with glass effect styling for better UX
- Fix loading state flash by checking both isBootstrapping and isLoadingSessions
- Set HomeView as default landing screen instead of Chat
- Simplify toolbar with waveform icon for Talk Now button

## Test plan
- [ ] Verify HomeView loads first on app launch
- [ ] Check connection status pill appears during sync (Connecting → Updating → gone)
- [ ] Confirm no empty state flash when opening sidebar
- [ ] Test Talk Now button with waveform icon in toolbar
- [ ] Verify skeleton loading state shows while chats load