### PR TITLE
Add delete account feature, fix onboarding UX, and improve sidebar

### DIFF
--- a/Backend/db/versions/20260218_0019_add_friend_invites_table.py
+++ b/Backend/db/versions/20260218_0019_add_friend_invites_table.py
@@ -1,0 +1,46 @@
+"""Track the existing friend_invites table in alembic.
+
+The table already exists in the database (created outside alembic).
+This migration uses IF NOT EXISTS so it is safe to run on both fresh
+and existing databases.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260218_0019"
+down_revision = "20260218_0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS public.friend_invites (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            inviter_user_id UUID NOT NULL REFERENCES auth.users(id),
+            token TEXT,
+            expires_at TIMESTAMP WITHOUT TIME ZONE,
+            created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
+            used_by_user_id UUID REFERENCES auth.users(id),
+            used_at TIMESTAMP WITHOUT TIME ZONE
+        );
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_friend_invites_inviter_user_id
+        ON public.friend_invites (inviter_user_id);
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_friend_invites_used_by_user_id
+        ON public.friend_invites (used_by_user_id);
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_friend_invites_used_by_user_id;")
+    op.execute("DROP INDEX IF EXISTS ix_friend_invites_inviter_user_id;")
+    op.execute("DROP TABLE IF EXISTS public.friend_invites;")

--- a/Backend/models/friends/friend_invite_model.py
+++ b/Backend/models/friends/friend_invite_model.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.schema import ForeignKey
+
+from ...database import Base
+
+
+class FriendInvite(Base):
+    __tablename__ = "friend_invites"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+
+    inviter_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auth.users.id", name="friend_invites_inviter_user_id_fkey"),
+        index=True,
+        nullable=False,
+    )
+
+    token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=False), nullable=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=False), server_default=func.now())
+
+    used_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auth.users.id", name="friend_invites_used_by_user_id_fkey"),
+        index=True,
+        nullable=True,
+    )
+    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=False), nullable=True)

--- a/Backend/subapps/user_profile_router.py
+++ b/Backend/subapps/user_profile_router.py
@@ -361,6 +361,77 @@ async def update_onboarding(payload: dict = Body(...), current_user: dict = Depe
         raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}")
 
 
+@router.delete("/account")
+async def delete_account(current_user: dict = Depends(get_current_user)):
+    try:
+        try:
+            user_id = uuid.UUID(current_user.get("sub"))
+        except Exception:
+            raise HTTPException(status_code=401, detail="Invalid user ID in token")
+
+        db = SessionLocal()
+        try:
+            from Backend.models.chat.chat_models import UserChatMessage, UserChatSession
+            from Backend.models.diary.diary_models import DiaryEntry, DiarySettings
+            from Backend.models.apns.device_token_model import DeviceToken
+            from Backend.models.client_uploads.upload_model import Upload
+            from Backend.models.friends.friend_code_model import FriendCode
+            from Backend.models.friends.friendship_model import Friendship
+            from Backend.models.friends.friend_invite_model import FriendInvite
+            from sqlalchemy import delete, or_
+
+            # Clear linked_session_id references before deleting sessions
+            db.execute(
+                UserChatSession.__table__.update()
+                .where(UserChatSession.user_id == user_id)
+                .values(linked_session_id=None)
+            )
+            # Also clear inbound linked_session_id pointing at this user's sessions
+            user_session_ids = db.execute(
+                UserChatSession.__table__.select()
+                .where(UserChatSession.user_id == user_id)
+                .with_only_columns(UserChatSession.id)
+            ).scalars().all()
+            if user_session_ids:
+                db.execute(
+                    UserChatSession.__table__.update()
+                    .where(UserChatSession.linked_session_id.in_(user_session_ids))
+                    .values(linked_session_id=None)
+                )
+
+            db.execute(delete(UserChatMessage).where(UserChatMessage.user_id == user_id))
+            db.execute(delete(UserChatSession).where(UserChatSession.user_id == user_id))
+            db.execute(delete(DiaryEntry).where(DiaryEntry.user_id == user_id))
+            db.execute(delete(DiarySettings).where(DiarySettings.user_id == user_id))
+            db.execute(delete(DeviceToken).where(DeviceToken.user_id == user_id))
+            db.execute(delete(Upload).where(Upload.user_id == user_id))
+            db.execute(delete(FriendCode).where(FriendCode.user_id == user_id))
+            db.execute(delete(Friendship).where(
+                or_(Friendship.user_low_id == user_id, Friendship.user_high_id == user_id)
+            ))
+            db.execute(delete(Profile).where(Profile.user_id == user_id))
+
+            db.execute(delete(FriendInvite).where(
+                or_(FriendInvite.inviter_user_id == user_id, FriendInvite.used_by_user_id == user_id)
+            ))
+
+            # Remove the Supabase auth record
+            db.execute(text("DELETE FROM auth.users WHERE id = :id"), {"id": str(user_id)})
+
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/presence")
 async def update_presence(payload: dict = Body(...), current_user: dict = Depends(get_current_user)):
     try:

--- a/TalkToMe/ContentView.swift
+++ b/TalkToMe/ContentView.swift
@@ -32,10 +32,7 @@ struct ContentView: View {
                         .transition(.opacity)
                 }
             } else if authService.isAuthenticated {
-                if !onboardingLoaded {
-                    onboardingLoadingView
-                        .transition(.opacity)
-                } else if onboardingVM.step != .completed {
+                if onboardingLoaded && onboardingVM.step != .completed {
                     OnboardingFlowView(viewModel: onboardingVM)
                         .transition(.opacity)
                 } else {
@@ -72,11 +69,26 @@ struct ContentView: View {
                 return
             }
 
-            onboardingLoaded = false
+            // Skip the loading screen for returning users who already completed onboarding.
+            let userId = authService.currentUserId ?? ""
+            let cacheKey = "onboarding_completed_\(userId)"
+            if !userId.isEmpty && UserDefaults.standard.bool(forKey: cacheKey) {
+                onboardingVM.step = .completed
+                onboardingLoaded = true
+            } else {
+                onboardingLoaded = false
+            }
+
             onboardingLoadTask = Task {
                 await onboardingVM.load()
                 await MainActor.run {
                     guard authService.isAuthenticated else { return }
+                    // Update the cache based on the server response.
+                    if onboardingVM.step == .completed && !userId.isEmpty {
+                        UserDefaults.standard.set(true, forKey: cacheKey)
+                    } else if !userId.isEmpty {
+                        UserDefaults.standard.removeObject(forKey: cacheKey)
+                    }
                     onboardingLoaded = true
                 }
             }
@@ -85,13 +97,6 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.3), value: authService.isCheckingAuth)
     }
 
-    private var onboardingLoadingView: some View {
-        ZStack {
-            AppTheme.background.ignoresSafeArea()
-            ProgressView("Preparing your account...")
-                .foregroundStyle(AppTheme.textSecondary)
-        }
-    }
 }
 
 #Preview {

--- a/TalkToMe/Services/Backend/BackendServiceProfile.swift
+++ b/TalkToMe/Services/Backend/BackendServiceProfile.swift
@@ -211,6 +211,22 @@ extension BackendService {
         return (try? jsonDecoder.decode(SimpleSuccess.self, from: data).success) ?? true
     }
 
+    // MARK: - Account Deletion
+
+    func deleteAccount(accessToken: String) async throws {
+        let url = baseURL
+            .appendingPathComponent("profile")
+            .appendingPathComponent("account")
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let serverMessage = decodeSimpleDetail(from: data) ?? String(data: data, encoding: .utf8) ?? "Unknown server error"
+            throw NSError(domain: "Backend", code: (response as? HTTPURLResponse)?.statusCode ?? -1, userInfo: [NSLocalizedDescriptionKey: serverMessage])
+        }
+    }
+
     // MARK: - Presence
 
     func updatePresence(online: Bool, accessToken: String) async throws {

--- a/TalkToMe/Services/GRDB-Service/LocalDatabase.swift
+++ b/TalkToMe/Services/GRDB-Service/LocalDatabase.swift
@@ -48,6 +48,19 @@ final class LocalDatabase {
         return String(cleaned)
     }
 
+    /// Closes and deletes the SQLite database for the current user.
+    func destroyCurrentUserDatabase() {
+        let key = currentUserKey()
+        lock.lock()
+        queuesByKey.removeValue(forKey: key)
+        lock.unlock()
+
+        let path = databaseURL(for: key).path
+        for suffix in ["", "-wal", "-shm"] {
+            try? fm.removeItem(atPath: path + suffix)
+        }
+    }
+
     private func baseDir() -> URL {
         let appSupport = try! fm.url(
             for: .applicationSupportDirectory,

--- a/TalkToMe/Settings/ViewModels/OnboardingViewModel.swift
+++ b/TalkToMe/Settings/ViewModels/OnboardingViewModel.swift
@@ -83,7 +83,12 @@ final class OnboardingViewModel: ObservableObject {
         // Verify via GET so we don't dismiss unless Supabase really has it.
         let refreshed = try await BackendService.shared.fetchOnboarding(accessToken: token)
         if Step(rawValue: refreshed.onboarding_step) == .completed {
-            await MainActor.run { self.step = .completed }
+            await MainActor.run {
+                self.step = .completed
+                if let userId = AuthService.shared.currentUserId, !userId.isEmpty {
+                    UserDefaults.standard.set(true, forKey: "onboarding_completed_\(userId)")
+                }
+            }
         } else {
             throw NSError(domain: "Onboarding", code: -1, userInfo: [NSLocalizedDescriptionKey: "Onboarding completion was not saved."])
         }

--- a/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
+++ b/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
@@ -13,6 +13,8 @@ class SettingsViewModel: ObservableObject {
     @Published var shouldNavigateToContacts: Bool = false
     @Published var shouldNavigateToAppearance: Bool = false
     @Published var shouldHighlightCustomization: Bool = false
+    @Published var showDeleteAccountConfirmation: Bool = false
+    @Published var isDeletingAccount: Bool = false
 
     private let avatarCacheManager = AvatarCacheManager.shared
 
@@ -111,6 +113,7 @@ class SettingsViewModel: ObservableObject {
                 icon: "",
                 gradient: [],
                 settings: [
+                    SettingItem(title: "Delete Account", subtitle: nil, type: .action, icon: "trash"),
                     SettingItem(title: "Sign Out", subtitle: nil, type: .action, icon: "rectangle.portrait.and.arrow.right")
                 ]
             )
@@ -147,12 +150,76 @@ class SettingsViewModel: ObservableObject {
         let setting = section.settings[settingIndex]
 
         switch setting.title {
+        case "Delete Account":
+            showDeleteAccountConfirmation = true
         case "Sign Out":
             Task {
                 await AuthService.shared.signOut()
             }
         default:
             break
+        }
+    }
+
+    func deleteAccount() {
+        // Grab token before signing out
+        let token = Task { await AuthService.shared.getAccessToken() }
+
+        // Sign out and purge local data immediately — don't block the UI
+        Self.purgeAllLocalData()
+        Task { await AuthService.shared.signOut() }
+
+        // Fire-and-forget backend deletion
+        Task.detached {
+            guard let token = await token.value else { return }
+            do {
+                try await BackendService.shared.deleteAccount(accessToken: token)
+            } catch {
+                print("Failed to delete account on server: \(error)")
+            }
+        }
+    }
+
+    /// Wipes every piece of locally-persisted user data: GRDB database, avatar cache, UserDefaults.
+    static func purgeAllLocalData() {
+        // 1. Destroy the local GRDB chat database (must happen while currentUserId is still set)
+        LocalDatabase.shared.destroyCurrentUserDatabase()
+
+        // 2. Clear avatar disk + memory cache
+        AvatarCacheManager.shared.clearCache()
+
+        // 3. Remove all UserDefaults keys set by the app
+        let keysToRemove = [
+            PreferenceKeys.appearancePreference,
+            PreferenceKeys.fontSizePreference,
+            PreferenceKeys.chatWallpaperType,
+            PreferenceKeys.chatWallpaperValue,
+            PreferenceKeys.hapticsEnabled,
+            PreferenceKeys.dictationEnabled,
+            PreferenceKeys.elevenLabsVoiceId,
+            PreferenceKeys.elevenLabsVoiceName,
+            PreferenceKeys.myAvatarURL,
+            PreferenceKeys.partnerUserId,
+            PreferenceKeys.partnerName,
+            PreferenceKeys.partnerAvatarURL,
+            PreferenceKeys.partnerDisplayName,
+            PreferenceKeys.partnerVoiceName,
+            PreferenceKeys.ttsVoiceIdentifier,
+            "talktome_profile_full_name",
+            "cached_notifications",
+            "get_started_dismissed",
+            "get_started_say_hi",
+            "get_started_connect_friend",
+            "get_started_write_diary",
+            "get_started_customize_buddy",
+        ]
+        for key in keysToRemove {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+
+        // Onboarding cache is keyed per-user
+        if let userId = AuthService.shared.currentUserId {
+            UserDefaults.standard.removeObject(forKey: "onboarding_completed_\(userId)")
         }
     }
 

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -252,31 +252,10 @@ struct FriendsAndContactsSectionView: View {
         }
     }
 
+    @ViewBuilder
     private var friendsSection: some View {
-        Section(header: Text("Friends")) {
-            if friendsViewModel.isLoadingFriends && friendsViewModel.friends.isEmpty {
-                HStack(spacing: 10) {
-                    ProgressView()
-                    Text("Loading...")
-                        .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
-                }
-            } else if friendsViewModel.friends.isEmpty {
-                VStack(spacing: 10) {
-                    Image(systemName: "person.2.slash")
-                        .font(.system(size: 28, weight: .light))
-                        .foregroundStyle(.tertiary)
-                    Text("No buddies yet")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.secondary)
-                    Text("Share your code or enter a friend's code above")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.tertiary)
-                        .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-            } else {
+        if !friendsViewModel.friends.isEmpty {
+            Section(header: Text("Friends")) {
                 ForEach(friendsViewModel.friends) { friend in
                     HStack(spacing: 14) {
                         ZStack(alignment: .bottomTrailing) {

--- a/TalkToMe/Settings/Views/SettingsView.swift
+++ b/TalkToMe/Settings/Views/SettingsView.swift
@@ -218,6 +218,11 @@ struct SettingsView: View {
       }
 
       ForEach(Array(section.settings.enumerated()), id: \.element.id) { settingIndex, setting in
+        if settingIndex > 0 {
+          Divider()
+            .padding(.leading, 60)
+        }
+
         Button(action: { viewModel.handleSettingAction(for: sectionIndex, settingIndex: settingIndex) }) {
           HStack(spacing: 14) {
             Image(systemName: setting.icon)
@@ -235,6 +240,7 @@ struct SettingsView: View {
           .frame(minHeight: 44)
         }
         .buttonStyle(PlainButtonStyle())
+        .disabled(setting.title == "Delete Account" && viewModel.isDeletingAccount)
       }
     }
     .padding(.vertical, 6)
@@ -324,6 +330,14 @@ struct SettingsView: View {
       .environmentObject(sessionsVM)
       .presentationDetents([.large])
       .presentationDragIndicator(.visible)
+    }
+    .alert("Delete Account", isPresented: $viewModel.showDeleteAccountConfirmation) {
+      Button("Delete", role: .destructive) {
+        viewModel.deleteAccount()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will permanently delete your account and all your data. This action cannot be undone.")
     }
     .preferredColorScheme(
       appearance == "Light" ? .light : appearance == "Dark" ? .dark : nil

--- a/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
+++ b/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
@@ -216,10 +216,17 @@ final class ChatSessionsViewModel: ObservableObject {
             if url.hasPrefix("http://") || url.hasPrefix("https://") {
                 UserDefaults.standard.set(url, forKey: PreferenceKeys.myAvatarURL)
             }
-            myAvatarURL = url
-            if oldURL != url {
-                NotificationCenter.default.post(name: .avatarChanged, object: nil)
+
+            // If the signed URL changed but the underlying image is the same,
+            // carry the cached image over to the new URL so the avatar doesn't flash.
+            if let oldURL, oldURL != url,
+               let existingImage = AvatarCacheManager.shared.getImageIfCached(urlString: oldURL) {
+                await AvatarCacheManager.shared.cacheImageImmediately(urlString: url, image: existingImage)
             }
+
+            myAvatarURL = url
+            // Only post avatarChanged when the user actually uploaded a new avatar,
+            // not when the signed URL simply rotated.
         } catch { }
     }
 

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -151,7 +151,7 @@ struct SidebarView: View {
     .toolbar {
       if !sessionsViewModel.sessions.isEmpty {
         ToolbarItem(placement: .topBarLeading) {
-          Text(" \(sessionsViewModel.sessions.count) Chats ")
+          Text(" \(sessionsViewModel.sessions.count) \(sessionsViewModel.sessions.count == 1 ? "chat" : "chats") ")
             .font(.system(size: 15, weight: .semibold))
             .foregroundStyle(Color(.label))
             .fixedSize()

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -116,7 +116,7 @@ struct SidebarView: View {
           }
 
           if filteredSessions.isEmpty {
-            loadingState
+            emptyState
           } else {
             ForEach(groupedSessions) { section in
               Text(section.title)
@@ -149,11 +149,13 @@ struct SidebarView: View {
     }
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        Text(" \(sessionsViewModel.sessions.count) Chats ")
-          .font(.system(size: 15, weight: .semibold))
-          .foregroundStyle(Color(.label))
-          .fixedSize()
+      if !sessionsViewModel.sessions.isEmpty {
+        ToolbarItem(placement: .topBarLeading) {
+          Text(" \(sessionsViewModel.sessions.count) Chats ")
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(Color(.label))
+            .fixedSize()
+        }
       }
 
       ToolbarItem(placement: .principal) {
@@ -210,16 +212,20 @@ struct SidebarView: View {
     .accessibilityHint("Start a new voice chat")
   }
 
+  private var effectiveVoiceName: String {
+    selectedVoiceName.isEmpty ? "luma" : selectedVoiceName
+  }
+
   @ViewBuilder
   private var ghostToolbarImage: some View {
-    if let videoName = ElevenLabsVoiceSuggestionsView.ghostVideoName(for: selectedVoiceName),
+    if let videoName = ElevenLabsVoiceSuggestionsView.ghostVideoName(for: effectiveVoiceName),
        Bundle.main.url(forResource: videoName, withExtension: "mp4") != nil {
       TransparentVideoPlayerView(
         videoName: videoName,
         videoExtension: "mp4",
         startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[videoName] ?? 0
       )
-    } else if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: selectedVoiceName) {
+    } else if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: effectiveVoiceName) {
       Image(uiImage: uiImage)
         .resizable()
         .scaledToFit()
@@ -389,48 +395,55 @@ struct SidebarView: View {
     }
   }
 
-  private var loadingState: some View {
-    VStack(spacing: 10) {
-      ForEach(0..<4, id: \.self) { index in
-        let shape = RoundedRectangle(cornerRadius: 18, style: .continuous)
-        HStack(spacing: 12) {
-          RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(Color(.systemGray5))
-            .frame(width: 36, height: 36)
+  private var emptyState: some View {
+    VStack(spacing: 24) {
+      ZStack {
+        ghostCard(name: "hex", size: 140)
+          .rotationEffect(.degrees(-8))
+          .offset(x: -60, y: 6)
 
-          VStack(alignment: .leading, spacing: 8) {
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
-              .fill(Color(.systemGray5))
-              .frame(width: index.isMultiple(of: 2) ? 150 : 110, height: 12)
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
-              .fill(Color(.systemGray6))
-              .frame(maxWidth: .infinity)
-              .frame(height: 10)
-          }
+        ghostCard(name: "jay", size: 110)
+          .rotationEffect(.degrees(5))
+          .offset(x: 0, y: -4)
 
-          Spacer()
+        ghostCard(name: "luma", size: 110)
+          .rotationEffect(.degrees(10))
+          .offset(x: 60, y: 6)
+      }
+      .frame(height: 140)
 
-          RoundedRectangle(cornerRadius: 5, style: .continuous)
-            .fill(Color(.systemGray5))
-            .frame(width: 34, height: 10)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 13)
-        .background {
-          if #available(iOS 26.0, *) {
-            Color.clear.glassEffect(.regular, in: shape)
-          } else {
-            shape.fill(AppTheme.surface.opacity(0.68))
-          }
-        }
-        .overlay {
-          shape.stroke(Color(.separator).opacity(0.16), lineWidth: 0.5)
-        }
-        .redacted(reason: .placeholder)
+      VStack(spacing: 8) {
+        Text("Your buddies are waiting!")
+          .font(.system(size: 17, weight: .bold))
+          .foregroundStyle(.primary)
+
+        let buddyName = ElevenLabsVoiceSuggestionsView.requiredBuddies.first(where: { $0.key == effectiveVoiceName })?.name ?? "Luma"
+        Text("Tap \(buddyName) to open a voice chat or tap + to start a regular chat.")
+          .font(.system(size: 14))
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 20)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.top, 160)
+  }
+
+  private func ghostCard(name: String, size: CGFloat = 110) -> some View {
+    Group {
+      if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: name) {
+        Image(uiImage: uiImage)
+          .resizable()
+          .scaledToFit()
+          .frame(width: size, height: size)
+      } else {
+        Image(systemName: "sparkles")
+          .font(.system(size: size * 0.33, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .frame(width: size, height: size)
       }
     }
   }
-
 
   // MARK: - Rename Sheet
 


### PR DESCRIPTION
## Summary
- Wire delete account across backend, DB, and iOS with immediate sign-out and background deletion
- Purge all local data (GRDB, cache, UserDefaults) on account deletion
- Remove onboarding loading screen, show main UI instantly with UserDefaults caching
- Fix avatar flash in toolbar by preserving cached images across signed URL rotation
- Add Luma ghost to sidebar empty state, remove loading skeleton for instant display
- Create FriendInvite model and alembic migration for friend invites table

## Test plan
- Delete account signs out immediately and clears all local data
- Onboarding loads from cache, avatar appears without flashing
- Sidebar empty state shows three ghost buddies (Hex, Jay, Luma)

🤖 Generated with Claude Code