### PR TITLE
Fix Settings lag from infinite animations

### DIFF
--- a/TalkToMe/Home/Views/HomeView.swift
+++ b/TalkToMe/Home/Views/HomeView.swift
@@ -480,8 +480,18 @@ private struct GetStartedCardView: View {
     .onAppear {
       // Seed checkpointVisible with already-completed steps
       checkpointVisible = completedStepIds
-      withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) {
-        dashPhase = -8
+      // Reset before starting to avoid stacking repeat-forever drivers
+      dashPhase = 0
+      DispatchQueue.main.async {
+        withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) {
+          dashPhase = -8
+        }
+      }
+    }
+    .onDisappear {
+      // Cancel the repeating animation to free the main thread
+      withAnimation(nil) {
+        dashPhase = 0
       }
     }
     .onChange(of: completedStepIds) { _, newIds in

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -141,10 +141,20 @@ struct FriendsAndContactsSectionView: View {
             .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
             .onAppear {
                 shimmerEnabled = true
+                // Reset before starting to avoid stacking repeat-forever drivers
                 shimmerPhase = -1.0
-                withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
-                    shimmerPhase = 1.0
+                DispatchQueue.main.async {
+                    withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
+                        shimmerPhase = 1.0
+                    }
                 }
+            }
+            .onDisappear {
+                // Cancel the repeating animation to free the main thread
+                withAnimation(nil) {
+                    shimmerPhase = -1.0
+                }
+                shimmerEnabled = false
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixed unresponsive Settings UI buttons that occurred after prolonged app usage. Root cause was two infinite `repeatForever` animations (dashPhase and shimmerPhase) running on the main thread without cleanup, causing accumulated animation frame workload to block user interactions.

## Changes
- Cancel dashPhase animation in GetStartedCardView on view disappear
- Cancel shimmerPhase animation in FriendsAndContactsSectionView on view disappear
- Reset animation state before restarting to prevent stacking of animation drivers

## Test plan
- Open app and navigate to Settings repeatedly
- Verify Settings button remains responsive after extended usage
- Verify animations still display correctly when views are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)