### PR TITLE
Implement ChatGPT-style voice mode UI with partner message display

### DIFF
--- a/TalkToMe/Chat/Views/ChatScreenView.swift
+++ b/TalkToMe/Chat/Views/ChatScreenView.swift
@@ -34,6 +34,12 @@ struct ChatScreenView: View {
     )
     .safeAreaInset(edge: .bottom, spacing: 0) {
       VStack(spacing: 0) {
+        // Ghost buddy circle — speak mode only, pushes messages up
+        if chatViewModel.isSpeakModeActive {
+          ghostBuddyCircle
+            .transition(.scale(scale: 0.3).combined(with: .opacity))
+        }
+
         InputAreaView(
         isVoiceRecording: chatViewModel.dictationSTTService.isRecording,
         isSpeakModeActive: chatViewModel.isSpeakModeActive,
@@ -87,7 +93,8 @@ struct ChatScreenView: View {
       .offset(y: inputAreaYOffset)
       .padding(.bottom, focusedBottomInset)
       .transition(.move(edge: .bottom).combined(with: .opacity))
-      } // VStack (reply bar + input)
+      } // VStack (ghost circle + input)
+      .animation(.smooth(duration: 0.45), value: chatViewModel.isSpeakModeActive)
     }
     .overlay(alignment: .top) {
       if let toastMessage {
@@ -100,6 +107,24 @@ struct ChatScreenView: View {
       AppTheme.background
         .ignoresSafeArea()
     }
+  }
+
+  @ViewBuilder
+  private var ghostBuddyCircle: some View {
+    Button(action: {
+      Haptics.impact(.medium)
+      chatViewModel.voiceController.stopSpeakMode()
+    }) {
+      GhostVideoContentView(
+        isSpeakModeActive: true,
+        speakModePhase: chatViewModel.voiceController.speakModePhase,
+        size: 150
+      )
+    }
+    .buttonStyle(.plain)
+    .frame(maxWidth: .infinity)
+    .padding(.top, 16)
+    .padding(.bottom, 8)
   }
 
   private func showDictationToast() {

--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -85,6 +85,9 @@ struct ChatView: View {
                     BuddyHeaderView(
                         isSpeakModeActive: viewModel.isSpeakModeActive,
                         speakModePhase: viewModel.voiceController.speakModePhase,
+                        connectedFriend: viewModel.selectedFriendUserId.flatMap { fid in
+                            friendsViewModel.friends.first(where: { $0.id == fid })
+                        },
                         onTap: {}
                     )
                 }

--- a/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
+++ b/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 /// Compact buddy identity shown in the chat toolbar's `.principal` slot.
 /// Shows ghost name + personality description, or voice status when speak mode is active.
+/// When a partner friend is connected, shows "with [avatar] [first_name]" instead of the description.
 struct BuddyHeaderView: View {
     @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = ""
 
     let isSpeakModeActive: Bool
     let speakModePhase: SpeakModePhase
+    let connectedFriend: FriendSummary?
     let onTap: () -> Void
 
     private var buddyDisplayName: String {
@@ -29,6 +31,13 @@ struct BuddyHeaderView: View {
         return Self.shortDescriptions[key] ?? ""
     }
 
+    private var friendFirstName: String? {
+        guard let friend = connectedFriend else { return nil }
+        let name = friend.fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return nil }
+        return String(name.split(separator: " ").first ?? Substring(name))
+    }
+
     var body: some View {
         Button(action: {
             Haptics.impact(.light)
@@ -42,6 +51,8 @@ struct BuddyHeaderView: View {
 
                 if isSpeakModeActive {
                     voiceStatusView
+                } else if let firstName = friendFirstName {
+                    friendSubtitleView(firstName: firstName)
                 } else if !buddyDescription.isEmpty {
                     Text(buddyDescription)
                         .font(.system(size: 11, weight: .medium))
@@ -56,6 +67,36 @@ struct BuddyHeaderView: View {
         .modifier(GlassEffectModifier())
         .animation(.easeInOut(duration: 0.2), value: isSpeakModeActive)
         .animation(.easeInOut(duration: 0.2), value: speakModePhase)
+        .animation(.smooth(duration: 0.45), value: connectedFriend?.id)
+    }
+
+    @ViewBuilder
+    private func friendSubtitleView(firstName: String) -> some View {
+        HStack(spacing: 4) {
+            Text("with")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.secondary)
+                .padding(.trailing, 4)
+
+            AvatarCacheManager.shared.cachedAsyncImage(
+                urlString: connectedFriend?.avatarURL,
+                placeholder: { AnyView(Color.clear.frame(width: 14, height: 14)) },
+                fallback: {
+                    AnyView(
+                        Image(systemName: "person.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                    )
+                }
+            )
+            .frame(width: 14, height: 14)
+            .clipShape(Circle())
+
+            Text(firstName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+        }
+        .lineLimit(1)
     }
 
     @ViewBuilder
@@ -111,6 +152,7 @@ private struct GlassEffectModifier: ViewModifier {
                     BuddyHeaderView(
                         isSpeakModeActive: false,
                         speakModePhase: .idle,
+                        connectedFriend: nil,
                         onTap: {}
                     )
                 }

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -39,8 +39,8 @@ struct InputAreaView: View {
     !(trimmedInput.isEmpty && pendingAttachments.isEmpty)
   }
 
-  /// Hide the ghost when typing, voice recording, attachments are present, or loading a response.
-  private var shouldHideGhost: Bool {
+  /// Hide speak-mode voice controls (mic mute + waveform capsule) when typing, recording, etc.
+  private var shouldHideVoiceControls: Bool {
     !trimmedInput.isEmpty || isVoiceRecording || !pendingAttachments.isEmpty
       || (isLoading && !isSpeakModeActive)
   }
@@ -53,7 +53,7 @@ struct InputAreaView: View {
     let outerHorizontalPadding: CGFloat = 32 * 2
     let outerSpacing: CGFloat = 4 * 2  // attachments<->capsule and capsule<->ghost
     let attachmentsButtonWidth: CGFloat = 44
-    let ghostButtonWidth: CGFloat = 46
+    let voiceModeButtonWidth: CGFloat = 44
 
     // Capsule padding (leading 14 + trailing 10)
     let capsuleHorizontalPadding: CGFloat = 14 + 10
@@ -65,7 +65,7 @@ struct InputAreaView: View {
       outerHorizontalPadding
       + outerSpacing
       + attachmentsButtonWidth
-      + ghostButtonWidth
+      + voiceModeButtonWidth
       + capsuleHorizontalPadding
       + trailingAccessoryInset
 
@@ -102,9 +102,6 @@ struct InputAreaView: View {
       return isSpeakMicMuted ? speakerLevel : max(speakerLevel, micLevel * 0.85)
     }
   }
-
-  // Ghost video logic is in GhostVideoContentView below to isolate
-  // @AppStorage re-renders from InputAreaView (prevents sheet/photo reload).
 
   // MARK: - Attachments button (Part 1)
   @available(iOS 26.0, *)
@@ -313,20 +310,23 @@ struct InputAreaView: View {
     .layoutPriority(1)
   }
 
-  // MARK: - Ghost button (Part 3)
+  // MARK: - Voice mode button (Part 3) — waveform (idle) / xmark (active)
   @available(iOS 26.0, *)
   @ViewBuilder
-  private var ghostButton: some View {
+  private var voiceModeButton: some View {
     Button(action: {
       Haptics.impact(.medium)
-      // Let the surrounding `.animation(..., value: isSpeakModeActive)` drive the transition.
-      // Explicit `withAnimation` here can cause SwiftUI to snapshot the representable,
-      // freezing the ghost video during the transition.
       onSpeakToggle()
     }) {
-      GhostVideoContentView(isSpeakModeActive: isSpeakModeActive, speakModePhase: speakModePhase)
+      Image(systemName: isSpeakModeActive ? "xmark" : "waveform")
+        .font(.system(size: 19, weight: .semibold))
+        .foregroundColor(.primary)
+        .contentTransition(.symbolEffect(.replace))
+        .frame(width: 44, height: 44)
     }
     .buttonStyle(.plain)
+    .glassEffect(.regular.interactive(), in: Circle())
+    .offset(y: -2)
   }
 
   var body: some View {
@@ -337,7 +337,7 @@ struct InputAreaView: View {
         messageCapsule
 
         // Mute mic button — separate glass circle, speak mode only (hide when typing)
-        if isSpeakModeActive && !shouldHideGhost {
+        if isSpeakModeActive && !shouldHideVoiceControls {
           Button(action: {
             Haptics.impact(.light)
             withAnimation(.smooth(duration: 0.3)) {
@@ -356,7 +356,7 @@ struct InputAreaView: View {
         }
 
         // Waveform capsule (speak mode only, hide when typing)
-        if isSpeakModeActive && !shouldHideGhost {
+        if isSpeakModeActive && !shouldHideVoiceControls {
           Button(action: {
             Haptics.impact(.medium)
             onSpeakToggle()
@@ -379,11 +379,9 @@ struct InputAreaView: View {
           .transition(.blurReplace)
         }
 
-        // Ghost — always mounted so the video never restarts
-        ghostButton
-          .offset(x: -2, y: isSpeakModeActive ? 4 : 1)
-          .opacity(!shouldHideGhost ? 1 : 0)
-          .frame(width: !shouldHideGhost ? nil : 0)
+        voiceModeButton
+          .opacity(!shouldHideVoiceControls ? 1 : 0)
+          .frame(width: !shouldHideVoiceControls ? nil : 0)
       }
       .padding(.vertical, 6)
       .padding(
@@ -397,8 +395,7 @@ struct InputAreaView: View {
         }
       )
       .animation(.spring(response: 0.35, dampingFraction: 0.85), value: isInputFocused.wrappedValue)
-      .animation(.smooth(duration: 0.45), value: isSpeakModeActive)
-      .animation(.smooth(duration: 0.35), value: shouldHideGhost)
+      .animation(.smooth(duration: 0.35), value: shouldHideVoiceControls)
       .onChange(of: isInputFocused.wrappedValue) { _, focused in
         if !focused {
           let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -430,9 +427,10 @@ struct InputAreaView: View {
 /// Owns the `@AppStorage` for voice selection so that voice changes only
 /// re-render this small view — not the entire InputAreaView (which would
 /// tear down the media picker sheet and reload photos).
-private struct GhostVideoContentView: View {
+struct GhostVideoContentView: View {
   let isSpeakModeActive: Bool
   let speakModePhase: SpeakModePhase
+  var size: CGFloat? = nil
 
   @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = ""
 
@@ -453,7 +451,7 @@ private struct GhostVideoContentView: View {
   }
 
   var body: some View {
-    let size: CGFloat = isSpeakModeActive ? 80 : 54
+    let resolvedSize: CGFloat = size ?? (isSpeakModeActive ? 80 : 54)
 
     ZStack {
       if hasGhostVideo && isSpeechActive {
@@ -469,7 +467,7 @@ private struct GhostVideoContentView: View {
           .transition(.opacity)
       }
     }
-    .frame(width: size, height: size)
+    .frame(width: resolvedSize, height: resolvedSize)
   }
 
   @ViewBuilder

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -306,11 +306,17 @@ struct MessagesListView: View {
             }
         }
         .onChange(of: isInputFocused, initial: false) { _, focused in
-            guard focused, isNearBottom, enforcedOffsetY == nil else { return }
+            guard isNearBottom, enforcedOffsetY == nil else { return }
             guard let sv = underlyingScrollView else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            if focused {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                    sv.layoutIfNeeded()
+                    scrollToBottomUIKit(sv, animated: true)
+                }
+            } else {
+                followBottom = true
                 sv.layoutIfNeeded()
-                scrollToBottomUIKit(sv, animated: true)
+                scrollToBottomUIKit(sv, animated: false)
             }
         }
         .onChange(of: chatViewModel.isLoadingHistory, initial: false) { _, loading in


### PR DESCRIPTION
## Summary
- Redesigned voice mode activation: waveform/xmark toggle button in input bar instead of ghost image
- Added large centered ghost buddy circle (150pt) that appears above input when speak mode activates
- Implemented partner message display: shows "with [avatar] [first_name]" in toolbar header when connected
- Fixed keyboard dismiss gap by scrolling to bottom immediately on focus loss

## Key Changes
- **InputAreaView**: Replaced ghost button with 44x44 glass circle button (waveform/xmark), made GhostVideoContentView public with optional size parameter
- **ChatScreenView**: Added ghost buddy circle in safeAreaInset that pushes messages up naturally
- **BuddyHeaderView**: Added partner friend display with smooth 0.45s animation between description and partner view
- **MessagesListView**: Fixed keyboard dismiss gap with immediate scroll-to-bottom on focus loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)