### PR TITLE
Fix partner message send flow and UI

### DIFF
--- a/TalkToMe/Chat/ViewModels/ChatViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatViewModel.swift
@@ -56,7 +56,6 @@ class ChatViewModel: ObservableObject {
         return messages.contains(where: { msg in
             msg.segments.contains(where: { seg in
                 if case .partnerReceived(_) = seg { return true }
-                if case .partnerMessage(_, _) = seg { return true }
                 return false
             })
         })

--- a/TalkToMe/Chat/Views/ChatView.swift
+++ b/TalkToMe/Chat/Views/ChatView.swift
@@ -168,12 +168,7 @@ struct ChatView: View {
             let content = (note.userInfo?["content"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             guard !content.isEmpty else { return }
             Task { @MainActor in
-                let success = await viewModel.unsendPartnerDraft(content)
-                NotificationCenter.default.post(
-                    name: .unsendPartnerMessageResult,
-                    object: nil,
-                    userInfo: ["content": content, "success": success]
-                )
+                _ = await viewModel.unsendPartnerDraft(content)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openAddFriendSheet)) { _ in

--- a/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
+++ b/TalkToMe/Chat/Views/Components/ElevenLabsVoiceSuggestionsView.swift
@@ -171,7 +171,7 @@ struct ElevenLabsVoiceSuggestionsView: View {
     static let ghostStartTimes: [String: Double] = [
         "jay": 0.2,
         "hex": 0.1,
-        "snow": 0.25
+        "snow": 0.3
     ]
 
     /// Pre-warm AVPlayers for all ghost videos so they display instantly in the media picker.

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -503,115 +503,128 @@ struct MessageBubbleView: View {
           }
         }
         .textSelection(.enabled)
-      } else if shouldShowThinkingIndicator || message.isFromPartnerUser || hasRenderableAssistantContent {
+      } else if message.isFromPartnerUser {
+        PartnerMessageBlockView(
+          text: plainText(from: message.segments),
+          senderUserId: message.senderUserId
+        )
+      } else if shouldShowThinkingIndicator || hasRenderableAssistantContent {
+        let hasTextContent = shouldShowThinkingIndicator || message.isToolLoading
+          || message.segments.contains(where: {
+            if case .text(let t) = $0 { return !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            return false
+          })
+        let partnerSegments = message.segments.filter { isPartnerSegment($0) }
+
         VStack(alignment: .leading, spacing: 8) {
-          if shouldShowThinkingIndicator {
-            if let thinkingText = activeStreamingThinkingText {
-              // Show "Thinking" header with live text (always expanded during streaming)
-              thinkingSectionView(text: thinkingText, alwaysExpanded: true)
-            } else {
-              ThinkingIndicatorView(
-                thinkingText: chatViewModel.thinkingText,
-                thinkingTextDone: chatViewModel.thinkingTextDone
-              )
-              .padding(.vertical, 4)
-            }
-          } else if message.isFromPartnerUser {
-            PartnerMessageBlockView(
-              text: plainText(from: message.segments),
-              senderUserId: message.senderUserId
-            )
-          } else if !message.segments.isEmpty {
-            // Collapsible thinking section
-            if let summary = effectiveThinkingText {
-              thinkingSectionView(text: summary, alwaysExpanded: false)
-            }
-
-            let attachmentSegments = message.segments.filter { isAttachmentSegment($0) }
-            if !attachmentSegments.isEmpty {
-              attachmentsView(segments: attachmentSegments, alignment: .leading)
-            }
-            ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
-              switch segment {
-              case .text(let text):
-                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                  MarkdownRendererView(markdown: text, isStreaming: isActivelyStreamingMessage)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 4)
+          if hasTextContent {
+            VStack(alignment: .leading, spacing: 8) {
+              if shouldShowThinkingIndicator {
+                if let thinkingText = activeStreamingThinkingText {
+                  thinkingSectionView(text: thinkingText, alwaysExpanded: true)
+                } else {
+                  ThinkingIndicatorView(
+                    thinkingText: chatViewModel.thinkingText,
+                    thinkingTextDone: chatViewModel.thinkingTextDone
+                  )
+                  .padding(.vertical, 4)
                 }
-              case .imageData(_), .imageURL(_), .fileData(_, _), .fileURL(_, _):
-                EmptyView()
-              case .partnerMessage(let text, let ghostName):
-                if !text.isEmpty {
-                  let isSent = chatViewModel.partnerDrafts.isPartnerDraftSent(
-                    sessionId: chatViewModel.sessionId, messageContent: text)
-                  let isLinked = chatViewModel.isConnectedToFriendInThisChat
-                  PartnerDraftBlockView(
-                    initialText: text,
-                    isSent: isSent,
-                    isLinked: isLinked,
-                    recipientUserId: chatViewModel.selectedFriendUserId,
-                    ghostName: ghostName ?? message.ghostName
-                  ) { action in
-                    switch action {
-                    case .send(let edited):
-                      onSendToPartner?(edited)
+              } else if !message.segments.isEmpty {
+                if let summary = effectiveThinkingText {
+                  thinkingSectionView(text: summary, alwaysExpanded: false)
+                }
+
+                let attachmentSegments = message.segments.filter { isAttachmentSegment($0) }
+                if !attachmentSegments.isEmpty {
+                  attachmentsView(segments: attachmentSegments, alignment: .leading)
+                }
+                ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
+                  switch segment {
+                  case .text(let text):
+                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                      MarkdownRendererView(markdown: text, isStreaming: isActivelyStreamingMessage)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 4)
                     }
+                  default:
+                    EmptyView()
                   }
-                  .id(text)
-                  .padding(.top, 6)
                 }
-              case .partnerReceived(let text):
-                if !text.isEmpty {
-                  PartnerMessageBlockView(text: text, senderUserId: message.senderUserId)
-                    .id("partner_received_\(text.hashValue)")
-                    .padding(.top, 6)
+                if message.isToolLoading {
+                  HStack {
+                    TypingIndicatorView(showAfter: 0.5)
+                    Spacer(minLength: 0)
+                  }
+                  .padding(.top, 2)
+                }
+
+                if shouldShowAssistantActions {
+                  AssistantMessageActionsView(
+                    messageText: plainText(from: message.segments),
+                    regenerationCount: message.regenerationCount,
+                    onRegenerate: onRegenerate,
+                    onToast: onToast,
+                    thinkingSummary: message.thinkingSummary,
+                    onToggleThinking: {
+                      withAnimation(.easeInOut(duration: 0.2)) {
+                        isThinkingExpanded.toggle()
+                      }
+                    }
+                  )
+                  .transition(.opacity.animation(.easeIn(duration: 0.2)))
+                }
+
+                if shouldShowVoiceRespondedLabel {
+                  Text(
+                    "\(voiceGhostDisplayName) responded at \(message.timestamp.formatted(date: .omitted, time: .shortened))"
+                  )
+                  .font(.system(size: 12, weight: .medium))
+                  .foregroundStyle(.secondary)
+                  .padding(.leading, 4)
+                  .transition(.opacity.animation(.easeIn(duration: 0.2)))
                 }
               }
             }
-            if message.isToolLoading {
-              HStack {
-                TypingIndicatorView(showAfter: 0.5)
-                Spacer(minLength: 0)
-              }
-              .padding(.top, 2)
-            }
+            .padding(12)
+            .background(AppTheme.talkToMeBubbleAI)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .foregroundColor(AppTheme.textPrimary)
+          }
 
-            // Action buttons for assistant messages
-            if shouldShowAssistantActions {
-              AssistantMessageActionsView(
-                messageText: plainText(from: message.segments),
-                regenerationCount: message.regenerationCount,
-                onRegenerate: onRegenerate,
-                onToast: onToast,
-                thinkingSummary: message.thinkingSummary,
-                onToggleThinking: {
-                  withAnimation(.easeInOut(duration: 0.2)) {
-                    isThinkingExpanded.toggle()
+          // Partner segments rendered outside the AI bubble
+          ForEach(Array(partnerSegments.enumerated()), id: \.offset) { _, segment in
+            switch segment {
+            case .partnerMessage(let text, let ghostName):
+              if !text.isEmpty {
+                let isSent = chatViewModel.partnerDrafts.isPartnerDraftSent(
+                  sessionId: chatViewModel.sessionId, messageContent: text)
+                let isLinked = chatViewModel.isConnectedToFriendInThisChat
+                PartnerDraftBlockView(
+                  initialText: text,
+                  isSent: isSent,
+                  isLinked: isLinked,
+                  recipientUserId: chatViewModel.selectedFriendUserId,
+                  ghostName: ghostName ?? message.ghostName
+                ) { action in
+                  switch action {
+                  case .send(let edited):
+                    onSendToPartner?(edited)
                   }
                 }
-              )
-              .transition(.opacity.animation(.easeIn(duration: 0.2)))
-            }
-
-            // "Snow responded at HH:mm" for voice mode messages
-            if shouldShowVoiceRespondedLabel {
-              Text(
-                "\(voiceGhostDisplayName) responded at \(message.timestamp.formatted(date: .omitted, time: .shortened))"
-              )
-              .font(.system(size: 12, weight: .medium))
-              .foregroundStyle(.secondary)
-              .padding(.leading, 4)
-              .transition(.opacity.animation(.easeIn(duration: 0.2)))
+                .id(text)
+              }
+            case .partnerReceived(let text):
+              if !text.isEmpty {
+                PartnerMessageBlockView(text: text, senderUserId: message.senderUserId)
+                  .id("partner_received_\(text.hashValue)")
+              }
+            default:
+              EmptyView()
             }
           }
         }
-        .padding(12)
-        .background(AppTheme.talkToMeBubbleAI)
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .foregroundColor(AppTheme.textPrimary)
       }
     }
     .frame(maxWidth: .infinity, alignment: message.isFromUser ? .trailing : .leading)
@@ -699,6 +712,15 @@ struct MessageBubbleView: View {
   private func isAttachmentSegment(_ seg: MessageSegment) -> Bool {
     switch seg {
     case .imageData(_), .imageURL(_), .fileData(_, _), .fileURL(_, _):
+      return true
+    default:
+      return false
+    }
+  }
+
+  private func isPartnerSegment(_ seg: MessageSegment) -> Bool {
+    switch seg {
+    case .partnerMessage(_, _), .partnerReceived(_):
       return true
     default:
       return false

--- a/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
@@ -14,7 +14,6 @@ struct PartnerDraftBlockView: View {
     @State private var showFriendMenu: Bool = false
     @State private var showFullFriendSheet: Bool = false
     @State private var selectedFriend: FriendSummary? = nil
-    @State private var isUnsending: Bool = false
     @State private var chevronNudge: Bool = false
 
     let initialText: String
@@ -129,7 +128,7 @@ struct PartnerDraftBlockView: View {
                     .transition(.scale.combined(with: .opacity))
                 }
 
-                if alreadySent && !isUnsending {
+                if alreadySent {
                     Button {
                         Haptics.impact(.light)
                         handleUnsend()
@@ -152,7 +151,7 @@ struct PartnerDraftBlockView: View {
                     sendButtonContent
                 }
                 .buttonStyle(.plain)
-                .disabled(isUnsending || alreadySent)
+                .disabled(alreadySent)
             }
 
             // Inline friend picker menu
@@ -172,7 +171,6 @@ struct PartnerDraftBlockView: View {
             showFriendMenu = false
             showFullFriendSheet = false
             selectedFriend = nil
-            isUnsending = false
         }
         .onChange(of: initialText) { _, newValue in
             self.text = newValue
@@ -181,25 +179,11 @@ struct PartnerDraftBlockView: View {
             showFriendMenu = false
             showFullFriendSheet = false
             selectedFriend = nil
-            isUnsending = false
         }
         .onChange(of: isSent) { _, _ in
             withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
                 isConfirmingNormalSend = false
                 showSentLocally = false
-                // Don't reset isUnsending here — let the result notification handle it
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .unsendPartnerMessageResult)) { note in
-            let content = (note.userInfo?["content"] as? String) ?? ""
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard content == trimmed else { return }
-            let success = (note.userInfo?["success"] as? Bool) ?? false
-            withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                isUnsending = false
-                if success {
-                    showSentLocally = false
-                }
             }
         }
         .sheet(isPresented: $showFullFriendSheet) {
@@ -317,7 +301,6 @@ struct PartnerDraftBlockView: View {
 
     /// Unique key for the current button state so SwiftUI can identity-transition between them.
     private var sendButtonStateId: String {
-        if isUnsending { return "unsending" }
         if alreadySent { return "sent" }
         if isConfirmingNormalSend { return "confirm" }
         if selectedFriend != nil { return "friend" }
@@ -328,10 +311,7 @@ struct PartnerDraftBlockView: View {
     @ViewBuilder
     private var sendButtonContent: some View {
         ZStack {
-            if isUnsending {
-                sendCapsule(label: "Unsending", icon: nil, color: .red.opacity(0.7), showSpinner: true)
-                    .transition(.opacity)
-            } else if alreadySent {
+            if alreadySent {
                 sendCapsule(label: "Sent", icon: "checkmark", color: .green)
                     .transition(.opacity)
             } else if isConfirmingNormalSend {
@@ -431,7 +411,7 @@ struct PartnerDraftBlockView: View {
         guard !trimmed.isEmpty else { return }
 
         withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-            isUnsending = true
+            showSentLocally = false
         }
         NotificationCenter.default.post(
             name: .unsendPartnerMessageFromBubble,

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -249,7 +249,6 @@ struct SidebarView: View {
     let shape = RoundedRectangle(cornerRadius: 18, style: .continuous)
 
     return Button(action: {
-      Haptics.impact(.light)
       onOpenChat(session.id)
     }) {
       HStack(alignment: .center, spacing: 12) {


### PR DESCRIPTION
## Summary
- Fixed bug where AI-drafted partner messages skipped friend selection by removing `.partnerMessage` from `isConnectedToFriendInThisChat` check
- Removed unsend spinner UI—button instantly switches back to Send while unsend happens in background
- Separated partner draft and received messages from AI message bubble background so they render independently
- Updated Snow video start time from 0.25s to 0.3s for optimal first frame
- Removed haptics when tapping a chat in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)