### PR TITLE
Backend device-token updates and app UI/chat refinements

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -1,3 +1,8 @@
+import logging
+from contextlib import asynccontextmanager
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
 from fastapi import FastAPI
 
 from .subapps.apple_router import router as aasa_router
@@ -10,8 +15,17 @@ from .subapps.client_upload_router import router as files_router
 from .subapps.friends_router import router as friends_router
 from .subapps.partner_router import router as partner_router
 from .subapps.user_profile_router import router as profile_router
+from .services.daily_checkin_scheduler import start_scheduler, stop_scheduler
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    start_scheduler()
+    yield
+    stop_scheduler()
+
+
+app = FastAPI(lifespan=lifespan)
 
 from Backend.middleware.presence import PresenceMiddleware  # noqa: E402
 

--- a/Backend/crud/apns/device_tokens_crud.py
+++ b/Backend/crud/apns/device_tokens_crud.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from starlette.concurrency import run_in_threadpool
 
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy import select, update
+from sqlalchemy import distinct, select, update
 
 from Backend.database import SessionLocal
 from Backend.models.apns.device_token_model import DeviceToken
@@ -13,30 +13,35 @@ from Backend.models.apns.device_token_model import DeviceToken
 TABLE = "device_tokens"
 
 
-async def upsert_token(*, user_id: uuid.UUID, token: str, platform: str, bundle_id: Optional[str]) -> None:
+async def upsert_token(*, user_id: uuid.UUID, token: str, platform: str, bundle_id: Optional[str], tz: Optional[str] = None) -> None:
     now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     def _upsert():
         db = SessionLocal()
         try:
+            values = dict(
+                user_id=user_id,
+                token=token,
+                platform=platform,
+                bundle_id=bundle_id,
+                enabled=True,
+                updated_at=now,
+            )
+            update_set = dict(
+                platform=platform,
+                bundle_id=bundle_id,
+                enabled=True,
+                updated_at=now,
+            )
+            if tz:
+                values["timezone"] = tz
+                update_set["timezone"] = tz
             stmt = (
                 insert(DeviceToken)
-                .values(
-                    user_id=user_id,
-                    token=token,
-                    platform=platform,
-                    bundle_id=bundle_id,
-                    enabled=True,
-                    updated_at=now,
-                )
+                .values(**values)
                 .on_conflict_do_update(
                     index_elements=[DeviceToken.user_id, DeviceToken.token],
-                    set_={
-                        "platform": platform,
-                        "bundle_id": bundle_id,
-                        "enabled": True,
-                        "updated_at": now,
-                    },
+                    set_=update_set,
                 )
             )
             db.execute(stmt)
@@ -81,3 +86,25 @@ async def list_tokens_for_user(*, user_id: uuid.UUID) -> List[dict]:
     return await run_in_threadpool(_select)
 
 
+async def list_users_by_timezone(*, tz: str) -> List[uuid.UUID]:
+    """Return distinct user IDs that have at least one enabled token in *tz*."""
+
+    def _select():
+        db = SessionLocal()
+        try:
+            rows = (
+                db.execute(
+                    select(distinct(DeviceToken.user_id))
+                    .where(
+                        DeviceToken.enabled.is_(True),
+                        DeviceToken.timezone == tz,
+                        DeviceToken.user_id.isnot(None),
+                    )
+                )
+                .all()
+            )
+            return [r[0] for r in rows]
+        finally:
+            db.close()
+
+    return await run_in_threadpool(_select)

--- a/Backend/crud/chat/chat_crud.py
+++ b/Backend/crud/chat/chat_crud.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from starlette.concurrency import run_in_threadpool
 
@@ -239,9 +239,10 @@ async def delete_partner_message(
     sender_user_id: uuid.UUID,
     sender_session_id: uuid.UUID,
     message_text: str,
-) -> bool:
+) -> Optional[Dict[str, Any]]:
     """Delete a partner message from the recipient's linked session.
-    Identifies the message by matching the JSON payload content."""
+    Identifies the message by matching the JSON payload content.
+    Returns recipient info dict on success, None on failure."""
     import json
 
     def _delete():
@@ -258,9 +259,22 @@ async def delete_partner_message(
                 .first()
             )
             if not sender_session or not sender_session.linked_session_id:
-                return False
+                return None
 
             recipient_session_id = sender_session.linked_session_id
+
+            # Resolve recipient user_id from their session
+            recipient_session = (
+                db.execute(
+                    select(UserChatSession).where(
+                        UserChatSession.id == recipient_session_id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            recipient_user_id = recipient_session.user_id if recipient_session else None
+
             expected_payload = json.dumps(
                 {
                     "_talktome": {
@@ -285,11 +299,15 @@ async def delete_partner_message(
                 .first()
             )
             if not msg:
-                return False
+                return None
 
             db.delete(msg)
             db.commit()
-            return True
+            return {
+                "deleted": True,
+                "recipient_user_id": recipient_user_id,
+                "recipient_session_id": recipient_session_id,
+            }
         finally:
             db.close()
 

--- a/Backend/db/versions/20260307_0020_add_device_tokens_unique_constraint.py
+++ b/Backend/db/versions/20260307_0020_add_device_tokens_unique_constraint.py
@@ -1,0 +1,58 @@
+"""Add unique constraint on (user_id, token) to device_tokens.
+
+The device_tokens table already exists in Supabase but is missing the
+unique constraint that the upsert_token CRUD operation requires for
+ON CONFLICT DO UPDATE.  Without it every token registration fails.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260307_0020"
+down_revision = "20260218_0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Ensure the table exists (safe no-op if it already does).
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS public.device_tokens (
+            id BIGSERIAL PRIMARY KEY,
+            user_id UUID REFERENCES auth.users(id),
+            token TEXT,
+            platform TEXT DEFAULT 'ios',
+            bundle_id TEXT,
+            enabled BOOLEAN DEFAULT true,
+            created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
+            updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT now()
+        );
+    """)
+
+    # Add the unique constraint required by the upsert CRUD.
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'device_tokens_user_id_token_key'
+            ) THEN
+                ALTER TABLE public.device_tokens
+                    ADD CONSTRAINT device_tokens_user_id_token_key
+                    UNIQUE (user_id, token);
+            END IF;
+        END$$;
+    """)
+
+    # Index for fast lookups by user_id (used by list_tokens_for_user).
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_device_tokens_user_id
+        ON public.device_tokens (user_id);
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE public.device_tokens DROP CONSTRAINT IF EXISTS device_tokens_user_id_token_key;")
+    op.execute("DROP INDEX IF EXISTS ix_device_tokens_user_id;")

--- a/Backend/db/versions/20260308_0021_add_timezone_to_device_tokens.py
+++ b/Backend/db/versions/20260308_0021_add_timezone_to_device_tokens.py
@@ -1,0 +1,26 @@
+"""Add timezone column to device_tokens.
+
+Stores the IANA timezone identifier (e.g. 'America/New_York') so the
+backend can schedule daily check-in notifications at 5 PM local time.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260308_0021"
+down_revision = "20260307_0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE public.device_tokens
+        ADD COLUMN IF NOT EXISTS timezone TEXT;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE public.device_tokens DROP COLUMN IF EXISTS timezone;")

--- a/Backend/middleware/presence.py
+++ b/Backend/middleware/presence.py
@@ -58,6 +58,11 @@ class PresenceMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
 
+        # Skip presence endpoint — the explicit online/offline signal manages
+        # its own last_seen_at; touching it here would defeat staleness checks.
+        if request.url.path.rstrip("/").endswith("/presence"):
+            return response
+
         if response.status_code < 200 or response.status_code >= 400:
             return response
 

--- a/Backend/models/apns/device_token_model.py
+++ b/Backend/models/apns/device_token_model.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Text, func
+from sqlalchemy import BigInteger, Boolean, DateTime, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.schema import ForeignKey
@@ -14,8 +14,11 @@ from ...database import Base
 
 class DeviceToken(Base):
     __tablename__ = "device_tokens"
+    __table_args__ = (
+        UniqueConstraint("user_id", "token", name="device_tokens_user_id_token_key"),
+    )
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("auth.users.id", name="device_tokens_user_id_fkey"),
@@ -26,5 +29,6 @@ class DeviceToken(Base):
     platform: Mapped[Optional[str]] = mapped_column(Text, nullable=True, server_default="ios")
     bundle_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     enabled: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True, server_default="true")
+    timezone: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=False), server_default=func.now())
     updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=False), server_default=func.now())

--- a/Backend/models/diary/diary_models.py
+++ b/Backend/models/diary/diary_models.py
@@ -1,18 +1,10 @@
-"""SQLAlchemy models for diary_settings and diary_entries.
-
-These tables are created by the migration and used directly from the iOS app
-via Supabase. The models here provide schema metadata for Alembic and optional
-Backend API use. Persistence of diary data happens from iOS → Supabase, not
-through these models unless you add Backend endpoints that use them.
-"""
-
 from __future__ import annotations
 
 import uuid
 from datetime import date, datetime
 from typing import Any, Optional
 
-from sqlalchemy import Date, DateTime, Text, func, text
+from sqlalchemy import Boolean, Date, DateTime, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.schema import ForeignKey
@@ -21,7 +13,6 @@ from ...database import Base
 
 
 class DiarySettings(Base):
-    """Per-user diary customization (name, description, header color)."""
 
     __tablename__ = "diary_settings"
     __table_args__ = {"schema": "public"}
@@ -41,7 +32,6 @@ class DiarySettings(Base):
 
 
 class DiaryEntry(Base):
-    """Diary/journal entry with body blocks (text + image upload references)."""
 
     __tablename__ = "diary_entries"
     __table_args__ = {"schema": "public"}
@@ -66,3 +56,24 @@ class DiaryEntry(Base):
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     timezone_abbreviation: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'UTC'::text"))
+
+
+class DiaryTodo(Base):
+
+    __tablename__ = "diary_todos"
+    __table_args__ = {"schema": "public"}
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auth.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    is_completed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -15,3 +15,4 @@ langchain-openai>=0.0.5
 chromadb>=0.4.22
 websockets
 google-genai>=1.0.0
+apscheduler>=3.10.0

--- a/Backend/services/apns_service.py
+++ b/Backend/services/apns_service.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import os
+import random
 import time
 import uuid
 from typing import Any, Dict, Optional
@@ -9,9 +11,28 @@ import jwt
 
 from ..crud.apns.device_tokens_crud import disable_token_by_value, list_tokens_for_user
 
+DAILY_CHECKIN_MESSAGES = [
+    "You've been on my mind. How are you really doing today?",
+    "Just checking in — you matter, and I'm here whenever you need to talk.",
+    "Hey, I hope today treated you well. Want to share what's on your mind?",
+    "Remember, it's okay to not be okay. I'm here if you need someone to listen.",
+    "You're doing better than you think. Want to reflect on your day together?",
+]
+
+logger = logging.getLogger(__name__)
 
 _cached_jwt_token: Optional[str] = None
 _cached_jwt_exp: float = 0.0
+
+# Persistent HTTP/2 client reused across all APNS requests.
+_apns_client: Optional[httpx.AsyncClient] = None
+
+
+def _get_apns_client() -> httpx.AsyncClient:
+    global _apns_client
+    if _apns_client is None or _apns_client.is_closed:
+        _apns_client = httpx.AsyncClient(http2=True, timeout=15.0)
+    return _apns_client
 
 
 def _load_apns_auth_key_pem() -> str:
@@ -47,7 +68,13 @@ def _get_apns_jwt_token() -> str:
     return token
 
 
-async def _post_apns(device_token: str, payload: Dict[str, Any]) -> tuple[int, str]:
+async def _post_apns(
+    device_token: str,
+    payload: Dict[str, Any],
+    *,
+    push_type: str = "alert",
+    priority: str = "10",
+) -> tuple[int, str]:
     prefer_sandbox = os.getenv("APNS_USE_SANDBOX", "true").lower() == "true"
     hosts_order = (
         ["api.sandbox.push.apple.com", "api.push.apple.com"]
@@ -65,24 +92,25 @@ async def _post_apns(device_token: str, payload: Dict[str, Any]) -> tuple[int, s
         return {
             "authorization": f"bearer {auth_token}",
             "apns-topic": bundle_id,
-            "apns-push-type": "alert",
-            "apns-priority": "10",
+            "apns-push-type": push_type,
+            "apns-priority": priority,
             "content-type": "application/json",
         }
 
     last_status = 0
     last_text = ""
+    client = _get_apns_client()
 
     for idx, host in enumerate(hosts_order):
         url = f"https://{host}/3/device/{device_token}"
-        async with httpx.AsyncClient(http2=True, timeout=10.0) as client:
-            resp = await client.post(url, headers=_headers(), content=json.dumps(payload))
-            last_status = resp.status_code
-            last_text = resp.text
+        resp = await client.post(url, headers=_headers(), content=json.dumps(payload))
+        last_status = resp.status_code
+        last_text = resp.text
 
         if last_status == 200:
             return last_status, last_text
         if idx == 0 and last_status in (400, 410) and ("BadDeviceToken" in (last_text or "")):
+            logger.info("[APNS] BadDeviceToken on %s, falling back to next host", host)
             continue
         break
 
@@ -95,6 +123,7 @@ async def send_friend_added_notification_to_user(
     sender_name: Optional[str] = None,
 ) -> None:
     tokens = await list_tokens_for_user(user_id=recipient_user_id)
+    logger.info("[APNS] friend_added -> user %s, %d token(s)", recipient_user_id, len(tokens))
     if not tokens:
         return
 
@@ -113,11 +142,14 @@ async def send_friend_added_notification_to_user(
             continue
         try:
             status, resp_text = await _post_apns(device_token=token_val, payload=payload)
+            logger.info("[APNS] friend_added status=%d resp=%s", status, resp_text[:200] if resp_text else "")
             if status != 200 and status in (400, 410) and (
                 "BadDeviceToken" in (resp_text or "") or "Unregistered" in (resp_text or "")
             ):
                 await disable_token_by_value(token=token_val)
-        except Exception:
+                logger.warning("[APNS] Disabled stale token: %s…", token_val[:12])
+        except Exception as exc:
+            logger.exception("[APNS] Failed to send friend_added push: %s", exc)
             continue
 
 
@@ -129,6 +161,7 @@ async def send_partner_message_notification_to_user(
     sender_name: Optional[str] = None,
 ) -> None:
     tokens = await list_tokens_for_user(user_id=recipient_user_id)
+    logger.info("[APNS] partner_message -> user %s, %d token(s)", recipient_user_id, len(tokens))
     if not tokens:
         return
 
@@ -148,9 +181,86 @@ async def send_partner_message_notification_to_user(
             continue
         try:
             status, resp_text = await _post_apns(device_token=token_val, payload=payload)
+            logger.info("[APNS] partner_message status=%d resp=%s", status, resp_text[:200] if resp_text else "")
             if status != 200 and status in (400, 410) and (
                 "BadDeviceToken" in (resp_text or "") or "Unregistered" in (resp_text or "")
             ):
                 await disable_token_by_value(token=token_val)
-        except Exception:
+                logger.warning("[APNS] Disabled stale token: %s…", token_val[:12])
+        except Exception as exc:
+            logger.exception("[APNS] Failed to send partner_message push: %s", exc)
+            continue
+
+
+async def send_unsend_notification_to_user(
+    *,
+    recipient_user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> None:
+    """Send a silent content-available push so the recipient's app can
+    retract the delivered notification and refresh its message list."""
+    tokens = await list_tokens_for_user(user_id=recipient_user_id)
+    logger.info("[APNS] partner_unsend -> user %s, %d token(s)", recipient_user_id, len(tokens))
+    if not tokens:
+        return
+
+    payload = {
+        "aps": {"content-available": 1},
+        "type": "partner_unsend",
+        "session_id": str(session_id),
+    }
+
+    for t in tokens:
+        token_val = t.get("token") if isinstance(t, dict) else None
+        enabled = t.get("enabled", True) if isinstance(t, dict) else True
+        if not token_val or not enabled:
+            continue
+        try:
+            status, resp_text = await _post_apns(
+                device_token=token_val,
+                payload=payload,
+                push_type="background",
+                priority="5",
+            )
+            logger.info("[APNS] partner_unsend status=%d resp=%s", status, resp_text[:200] if resp_text else "")
+            if status != 200 and status in (400, 410) and (
+                "BadDeviceToken" in (resp_text or "") or "Unregistered" in (resp_text or "")
+            ):
+                await disable_token_by_value(token=token_val)
+                logger.warning("[APNS] Disabled stale token: %s…", token_val[:12])
+        except Exception as exc:
+            logger.exception("[APNS] Failed to send partner_unsend push: %s", exc)
+            continue
+
+
+async def send_daily_checkin_notification(*, user_id: uuid.UUID) -> None:
+    """Send a randomized supportive check-in push notification to a user."""
+    tokens = await list_tokens_for_user(user_id=user_id)
+    logger.info("[APNS] daily_checkin -> user %s, %d token(s)", user_id, len(tokens))
+    if not tokens:
+        return
+
+    message = random.choice(DAILY_CHECKIN_MESSAGES)
+    aps = {
+        "alert": {"title": "TalkToMe", "body": message},
+        "sound": "default",
+        "category": "DAILY_CHECKIN",
+    }
+    payload = {"aps": aps, "type": "daily_checkin"}
+
+    for t in tokens:
+        token_val = t.get("token") if isinstance(t, dict) else None
+        enabled = t.get("enabled", True) if isinstance(t, dict) else True
+        if not token_val or not enabled:
+            continue
+        try:
+            status, resp_text = await _post_apns(device_token=token_val, payload=payload)
+            logger.info("[APNS] daily_checkin status=%d resp=%s", status, resp_text[:200] if resp_text else "")
+            if status != 200 and status in (400, 410) and (
+                "BadDeviceToken" in (resp_text or "") or "Unregistered" in (resp_text or "")
+            ):
+                await disable_token_by_value(token=token_val)
+                logger.warning("[APNS] Disabled stale token: %s…", token_val[:12])
+        except Exception as exc:
+            logger.exception("[APNS] Failed to send daily_checkin push: %s", exc)
             continue

--- a/Backend/services/chat_service.py
+++ b/Backend/services/chat_service.py
@@ -230,10 +230,12 @@ class VoiceChatService:
 
         async def event_generator() -> AsyncIterator[GeminiStreamEvent]:
             if not self.client:
+                print("[VoiceAgent][Gemini] ERROR: GEMINI_API_KEY not configured")
                 yield GeminiStreamEvent(type="response.error", error="GEMINI_API_KEY not configured")
                 return
 
             try:
+                print(f"[VoiceAgent][Gemini] starting stream — model={self.model_name} system_instruction_len={len(system_instruction or '')} contents_count={len(contents)}")
                 # Emit response.created event
                 yield GeminiStreamEvent(type="response.created")
 
@@ -246,6 +248,7 @@ class VoiceChatService:
 
                 # Use async streaming with multi-turn contents
                 chunk_count = 0
+                total_text_len = 0
                 async for chunk in await self.client.aio.models.generate_content_stream(
                     model=self.model_name,
                     contents=contents,
@@ -253,6 +256,7 @@ class VoiceChatService:
                 ):
                     chunk_count += 1
                     if chunk.text:
+                        total_text_len += len(chunk.text)
                         yield GeminiStreamEvent(
                             type="response.output_text.delta",
                             delta=chunk.text,
@@ -265,16 +269,17 @@ class VoiceChatService:
                             if chunk.candidates:
                                 finish_reason = chunk.candidates[0].finish_reason
                                 safety_ratings = chunk.candidates[0].safety_ratings
-                        print(f"[Gemini] Empty chunk #{chunk_count}: finish_reason={finish_reason} safety={safety_ratings}")
+                        print(f"[VoiceAgent][Gemini] Empty chunk #{chunk_count}: finish_reason={finish_reason} safety={safety_ratings}")
 
                 if chunk_count == 0:
-                    print("[Gemini] WARNING: Stream returned zero chunks")
+                    print("[VoiceAgent][Gemini] WARNING: Stream returned zero chunks")
 
+                print(f"[VoiceAgent][Gemini] stream completed — chunks={chunk_count} total_text_len={total_text_len}")
                 # Emit response.completed event
                 yield GeminiStreamEvent(type="response.completed")
 
             except Exception as e:
-                print(f"[Gemini] Stream error: {e}")
+                print(f"[VoiceAgent][Gemini] Stream error: {e}")
                 yield GeminiStreamEvent(type="response.error", error=str(e))
 
         yield event_generator()

--- a/Backend/services/daily_checkin_scheduler.py
+++ b/Backend/services/daily_checkin_scheduler.py
@@ -1,0 +1,72 @@
+"""Scheduler that sends daily 5 PM check-in notifications per timezone.
+
+Runs a job every hour on the hour.  For each run it computes which IANA
+timezones currently have local hour == 17 and sends a supportive push
+notification to every user whose device token is registered in one of
+those timezones.
+"""
+
+import logging
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, available_timezones
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from ..crud.apns.device_tokens_crud import list_users_by_timezone
+from .apns_service import send_daily_checkin_notification
+
+logger = logging.getLogger(__name__)
+
+_scheduler: AsyncIOScheduler | None = None
+
+
+def _timezones_at_hour(hour: int = 17) -> list[str]:
+    """Return IANA timezone names whose current local hour equals *hour*."""
+    now_utc = datetime.now(timezone.utc)
+    result = []
+    for tz_name in available_timezones():
+        try:
+            local_time = now_utc.astimezone(ZoneInfo(tz_name))
+            if local_time.hour == hour:
+                result.append(tz_name)
+        except Exception:
+            continue
+    return result
+
+
+async def _send_checkins_for_timezone(tz: str) -> None:
+    user_ids = await list_users_by_timezone(tz=tz)
+    if not user_ids:
+        return
+    logger.info("[DailyCheckin] Sending to %d user(s) in %s", len(user_ids), tz)
+    for uid in user_ids:
+        try:
+            await send_daily_checkin_notification(user_id=uid)
+        except Exception:
+            logger.exception("[DailyCheckin] Failed for user %s", uid)
+
+
+async def _daily_checkin_job() -> None:
+    """Hourly job: find timezones at 5 PM and send check-ins."""
+    matching = _timezones_at_hour(17)
+    logger.info("[DailyCheckin] Timezones at 5 PM: %d", len(matching))
+    for tz in matching:
+        await _send_checkins_for_timezone(tz)
+
+
+def start_scheduler() -> None:
+    global _scheduler
+    if _scheduler is not None:
+        return
+    _scheduler = AsyncIOScheduler()
+    _scheduler.add_job(_daily_checkin_job, "cron", minute=0, id="daily_checkin")
+    _scheduler.start()
+    logger.info("[DailyCheckin] Scheduler started (runs every hour at :00)")
+
+
+def stop_scheduler() -> None:
+    global _scheduler
+    if _scheduler:
+        _scheduler.shutdown(wait=False)
+        _scheduler = None
+        logger.info("[DailyCheckin] Scheduler stopped")

--- a/Backend/subapps/apns_router.py
+++ b/Backend/subapps/apns_router.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime, timezone
 
@@ -7,6 +8,8 @@ from Backend.auth import get_current_user
 from Backend.crud.apns.device_tokens_crud import disable_token_by_value, upsert_token
 from sqlalchemy import text
 from Backend.database import SessionLocal
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
@@ -36,13 +39,16 @@ async def register_token(payload: dict, current_user: dict = Depends(get_current
     token = payload.get("token")
     platform = payload.get("platform") or "ios"
     bundle_id = payload.get("bundle_id")
+    tz = payload.get("timezone")
     if not token or not isinstance(token, str) or len(token) < 10:
         raise HTTPException(status_code=400, detail="Missing or invalid device token")
 
     try:
-        await upsert_token(user_id=user_uuid, token=token, platform=platform, bundle_id=bundle_id)
+        await upsert_token(user_id=user_uuid, token=token, platform=platform, bundle_id=bundle_id, tz=tz)
+        logger.info("[APNS] Registered token for user %s (token=%s…)", user_uuid, token[:12])
         return {"success": True}
     except Exception as e:
+        logger.exception("[APNS] Failed to register token for user %s: %s", user_uuid, e)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/Backend/subapps/chat_router.py
+++ b/Backend/subapps/chat_router.py
@@ -485,6 +485,8 @@ async def chat_message_stream(http_request: Request, chat_request: ChatRequest, 
                             continue
 
                 use_voice_agent = bool((chat_request.voice_agent or "").strip())
+                if use_voice_agent:
+                    print(f"[VoiceAgent] voice_agent mode detected — agent='{chat_request.voice_agent}' session={session_uuid} message_len={len((chat_request.message or '').strip())}")
 
                 # RAG: retrieve relevant book chunks from Supabase.
                 # Skip RAG for voice mode to reduce latency.

--- a/Backend/subapps/friends_router.py
+++ b/Backend/subapps/friends_router.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -133,6 +134,9 @@ async def add_by_code(request: AddFriendByCodeRequest, current_user: dict = Depe
     return AddFriendByCodeResponse(success=True, friend_user_id=friend_id)
 
 
+_ONLINE_STALE_SECONDS = 5 * 60  # treat is_online as stale after 5 min of inactivity
+
+
 @router.get("", response_model=FriendsListResponse)
 async def list_friends(http_request: Request, current_user: dict = Depends(get_current_user)):
     try:
@@ -143,6 +147,7 @@ async def list_friends(http_request: Request, current_user: dict = Depends(get_c
     try:
         ids = await list_friends_for_user(user_id=user_id)
         base_url = _resolve_public_base_url(http_request)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         out: list[FriendSummary] = []
         for fid in ids:
             profile = _profile_fields_for_user(fid)
@@ -164,6 +169,13 @@ async def list_friends(http_request: Request, current_user: dict = Depends(get_c
             last_seen_dt = profile.get("last_seen_at")
             last_seen_str = last_seen_dt.isoformat() + "Z" if last_seen_dt else None
 
+            # Guard against stale is_online: if last_seen_at is too old, the
+            # app likely got killed before it could send the offline signal.
+            is_online = bool(profile.get("is_online", False))
+            if is_online and last_seen_dt is not None:
+                if (now - last_seen_dt).total_seconds() > _ONLINE_STALE_SECONDS:
+                    is_online = False
+
             out.append(
                 FriendSummary(
                     user_id=fid,
@@ -171,7 +183,7 @@ async def list_friends(http_request: Request, current_user: dict = Depends(get_c
                     auth_provider=auth_provider,
                     avatar_url=avatar_url,
                     last_seen_at=last_seen_str,
-                    is_online=bool(profile.get("is_online", False)),
+                    is_online=is_online,
                 )
             )
         return FriendsListResponse(friends=out)

--- a/Backend/subapps/partner_router.py
+++ b/Backend/subapps/partner_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Optional
 
@@ -20,10 +21,12 @@ from Backend.crud.friends.friends_crud import get_friendship_id_for_pair
 from Backend.database import SessionLocal
 from Backend.models.friends.friendship_model import Friendship
 from Backend.models.profile.profile_model import Profile
-from Backend.services.apns_service import send_partner_message_notification_to_user
+from Backend.services.apns_service import send_partner_message_notification_to_user, send_unsend_notification_to_user
 from sqlalchemy import text as sa_text
 from starlette.concurrency import run_in_threadpool
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/partner", tags=["partner"])
 
@@ -179,9 +182,9 @@ async def send_message(request: SendPartnerMessageRequest, current_user: dict = 
             preview=message[:120],
             sender_name=sender_name,
         )
-    except Exception:
+    except Exception as exc:
         # Push failures should not block sending.
-        pass
+        logger.exception("[PARTNER] Push notification failed for recipient %s: %s", recipient_user_id, exc)
 
     return SendPartnerMessageResponse(success=True, recipient_session_id=recipient_session_id)
 
@@ -206,13 +209,25 @@ async def unsend_message(request: UnsendPartnerMessageRequest, current_user: dic
     if not message_text:
         raise HTTPException(status_code=400, detail="message_text required")
 
-    deleted = await delete_partner_message(
+    result = await delete_partner_message(
         sender_user_id=user_id,
         sender_session_id=request.session_id,
         message_text=message_text,
     )
-    if not deleted:
+    if not result:
         raise HTTPException(status_code=404, detail="Message not found or already deleted")
+
+    # Send silent push so recipient's app retracts the notification.
+    recipient_user_id = result.get("recipient_user_id")
+    recipient_session_id = result.get("recipient_session_id")
+    if recipient_user_id and recipient_session_id:
+        try:
+            await send_unsend_notification_to_user(
+                recipient_user_id=recipient_user_id,
+                session_id=recipient_session_id,
+            )
+        except Exception as exc:
+            logger.exception("[PARTNER] Unsend push failed for recipient %s: %s", recipient_user_id, exc)
 
     return UnsendPartnerMessageResponse(success=True)
 

--- a/Backend/subapps/user_profile_router.py
+++ b/Backend/subapps/user_profile_router.py
@@ -380,27 +380,59 @@ async def delete_account(current_user: dict = Depends(get_current_user)):
             from Backend.models.friends.friend_invite_model import FriendInvite
             from sqlalchemy import delete, or_
 
-            # Clear linked_session_id references before deleting sessions
-            db.execute(
-                UserChatSession.__table__.update()
-                .where(UserChatSession.user_id == user_id)
-                .values(linked_session_id=None)
-            )
-            # Also clear inbound linked_session_id pointing at this user's sessions
+            # Collect the user's session IDs
             user_session_ids = db.execute(
                 UserChatSession.__table__.select()
                 .where(UserChatSession.user_id == user_id)
                 .with_only_columns(UserChatSession.id)
             ).scalars().all()
-            if user_session_ids:
+
+            # Collect friendship IDs and the friend's linked sessions
+            friendship_ids = db.execute(
+                Friendship.__table__.select()
+                .where(or_(Friendship.user_low_id == user_id, Friendship.user_high_id == user_id))
+                .with_only_columns(Friendship.id)
+            ).scalars().all()
+
+            friend_session_ids = []
+            if friendship_ids:
+                friend_session_ids = db.execute(
+                    UserChatSession.__table__.select()
+                    .where(
+                        UserChatSession.friendship_id.in_(friendship_ids),
+                        UserChatSession.user_id != user_id,
+                    )
+                    .with_only_columns(UserChatSession.id)
+                ).scalars().all()
+
+            all_session_ids = list(user_session_ids) + list(friend_session_ids)
+
+            # Clear linked_session_id references before deleting sessions
+            if all_session_ids:
                 db.execute(
                     UserChatSession.__table__.update()
-                    .where(UserChatSession.linked_session_id.in_(user_session_ids))
+                    .where(UserChatSession.linked_session_id.in_(all_session_ids))
                     .values(linked_session_id=None)
                 )
+            db.execute(
+                UserChatSession.__table__.update()
+                .where(UserChatSession.user_id == user_id)
+                .values(linked_session_id=None)
+            )
 
-            db.execute(delete(UserChatMessage).where(UserChatMessage.user_id == user_id))
+            # Delete all messages in affected sessions (user's + friend's linked sessions)
+            if all_session_ids:
+                db.execute(delete(UserChatMessage).where(
+                    or_(UserChatMessage.user_id == user_id, UserChatMessage.session_id.in_(all_session_ids))
+                ))
+            else:
+                db.execute(delete(UserChatMessage).where(UserChatMessage.user_id == user_id))
+
+            # Delete all affected sessions (user's + friend's linked sessions)
+            if friend_session_ids:
+                db.execute(delete(UserChatSession).where(UserChatSession.id.in_(friend_session_ids)))
             db.execute(delete(UserChatSession).where(UserChatSession.user_id == user_id))
+
             db.execute(delete(DiaryEntry).where(DiaryEntry.user_id == user_id))
             db.execute(delete(DiarySettings).where(DiarySettings.user_id == user_id))
             db.execute(delete(DeviceToken).where(DeviceToken.user_id == user_id))
@@ -440,9 +472,12 @@ async def update_presence(payload: dict = Body(...), current_user: dict = Depend
         raise HTTPException(status_code=401, detail="Invalid user ID in token")
 
     online = bool(payload.get("online", False))
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
-    update_data = {"is_online": online, "last_seen_at": now}
+    update_data: dict = {"is_online": online}
+    # Only touch last_seen_at when coming online; when going offline we
+    # preserve the existing timestamp so staleness checks work immediately.
+    if online:
+        update_data["last_seen_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
     _upsert_profile(user_id, update_data)
 
     return {"success": True}

--- a/TalkToMe/AppDelegate.swift
+++ b/TalkToMe/AppDelegate.swift
@@ -16,6 +16,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         print("[Push] Failed to register: \(error.localizedDescription)")
     }
 
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        Task { @MainActor in
+            APNSService.shared.handleBackgroundPush(userInfo: userInfo)
+            completionHandler(.newData)
+        }
+    }
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         let sourceApp = options[.sourceApplication] as? String ?? "unknown"
         print("[URL] AppDelegate openURL: \(url.absoluteString), sourceApp: \(sourceApp)")

--- a/TalkToMe/AuthView.swift
+++ b/TalkToMe/AuthView.swift
@@ -107,6 +107,7 @@ struct AuthView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 15)
+                .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
             .modifier(AuthSecondaryButtonStyle())
@@ -120,6 +121,7 @@ struct AuthView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 15)
+                .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
             .modifier(AuthAppleButtonStyle())
@@ -145,6 +147,7 @@ struct AuthView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 15)
+                    .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
             .modifier(AuthSecondaryButtonStyle())
@@ -157,6 +160,7 @@ struct AuthView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 15)
+                    .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
             .modifier(AuthPrimaryButtonStyle())
@@ -347,9 +351,11 @@ private struct EmailLoginView: View {
 
     @State private var email: String = ""
     @State private var password: String = ""
+    @State private var showPassword: Bool = false
     @State private var isSubmitting: Bool = false
     @State private var showOfflineAlert: Bool = false
-    @State private var localError: String? = nil
+    @State private var toastMessage: String? = nil
+    @State private var toastWorkItem: DispatchWorkItem? = nil
 
     var body: some View {
         ZStack {
@@ -374,18 +380,31 @@ private struct EmailLoginView: View {
                             .textContentType(.username)
                             .modifier(AuthTextFieldStyle())
 
-                        SecureField("Password", text: $password)
-                            .textContentType(.password)
-                            .modifier(AuthTextFieldStyle())
+                        ZStack {
+                            if showPassword {
+                                TextField("Password", text: $password)
+                                    .textContentType(.password)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled(true)
+                            } else {
+                                SecureField("Password", text: $password)
+                                    .textContentType(.password)
+                            }
+                        }
+                        .modifier(AuthTextFieldStyle())
+                        .overlay(alignment: .trailing) {
+                            Button {
+                                showPassword.toggle()
+                            } label: {
+                                Image(systemName: showPassword ? "eye.slash" : "eye")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(AppTheme.textSecondary)
+                            }
+                            .padding(.trailing, 14)
+                        }
                     }
                     .padding(16)
                     .modifier(AuthPanelCardStyle())
-
-                    if let err = (localError ?? authService.lastAuthError), !err.isEmpty {
-                        Text(err)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                    }
 
                     Button(action: submit) {
                         HStack(spacing: 10) {
@@ -397,6 +416,7 @@ private struct EmailLoginView: View {
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
+                        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
                     .buttonStyle(.plain)
                     .modifier(AuthPrimaryButtonStyle())
@@ -435,11 +455,31 @@ private struct EmailLoginView: View {
         } message: {
             Text("Connect to the internet to log in.")
         }
+        .overlay(alignment: .top) {
+            if let toastMessage {
+                ToastOverlayView(message: toastMessage, onDismiss: dismissToast)
+                    .padding(.top, 8)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
+    }
+
+    private func showToast(_ message: String) {
+        toastWorkItem?.cancel()
+        Haptics.notification(.warning)
+        withAnimation { toastMessage = message }
+        let work = DispatchWorkItem { withAnimation { toastMessage = nil } }
+        toastWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: work)
+    }
+
+    private func dismissToast() {
+        toastWorkItem?.cancel()
+        withAnimation { toastMessage = nil }
     }
 
     private func submit() {
         Haptics.selection()
-        localError = nil
 
         guard network.isOnline else {
             showOfflineAlert = true
@@ -448,15 +488,15 @@ private struct EmailLoginView: View {
 
         let e = email.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !e.isEmpty else {
-            localError = "Enter your email address."
+            showToast("Enter your email address.")
             return
         }
         guard isPlausibleEmail(e) else {
-            localError = "Enter a valid email address."
+            showToast("Enter a valid email address.")
             return
         }
         guard !password.isEmpty else {
-            localError = "Enter your password."
+            showToast("Enter your password.")
             return
         }
 
@@ -467,6 +507,8 @@ private struct EmailLoginView: View {
                 isSubmitting = false
                 if authService.isAuthenticated {
                     dismiss()
+                } else if let err = authService.lastAuthError, !err.isEmpty {
+                    showToast(err)
                 }
             }
         }
@@ -488,9 +530,12 @@ private struct EmailSignUpView: View {
     @ObservedObject private var authService = AuthService.shared
     @Environment(\.dismiss) private var dismiss
 
+    @State private var firstName: String = ""
     @State private var email: String = ""
     @State private var password: String = ""
     @State private var confirmPassword: String = ""
+    @State private var showPassword: Bool = false
+    @State private var showConfirmPassword: Bool = false
 
     @FocusState private var focusedField: Field?
     @State private var isSubmitting: Bool = false
@@ -500,7 +545,7 @@ private struct EmailSignUpView: View {
     @State private var emailCheckTask: Task<Void, Never>? = nil
     @State private var emailCheckState: EmailCheckState = .idle
 
-    private enum Field { case email, password, confirm }
+    private enum Field { case firstName, email, password, confirm }
     private enum EmailCheckState: Equatable {
         case idle
         case checking
@@ -512,8 +557,9 @@ private struct EmailSignUpView: View {
     private var trimmedEmail: String { email.trimmingCharacters(in: .whitespacesAndNewlines) }
     private var normalizedEmail: String { normalizeEmail(email) }
 
+    private var trimmedFirstName: String { firstName.trimmingCharacters(in: .whitespacesAndNewlines) }
     private var hasValidDetails: Bool {
-        isPlausibleEmail(trimmedEmail)
+        !trimmedFirstName.isEmpty && isPlausibleEmail(trimmedEmail)
     }
 
     private var hasValidPassword: Bool { password.count >= 6 }
@@ -527,6 +573,7 @@ private struct EmailSignUpView: View {
     }
 
     private var validationHint: String {
+        if trimmedFirstName.isEmpty { return "Enter your first name." }
         if !isPlausibleEmail(trimmedEmail) { return "Enter a valid email address." }
         switch emailCheckState {
         case .idle, .checking:
@@ -551,13 +598,21 @@ private struct EmailSignUpView: View {
                 VStack(alignment: .leading, spacing: 22) {
                     AuthSheetHeader(
                         title: "Create account",
-                        subtitle: "Name will be collected in onboarding after you sign in."
+                        subtitle: "Let's get you set up."
                     )
 
                     VStack(alignment: .leading, spacing: 14) {
-                        Text("Create credentials")
+                        Text("Your details")
                             .font(.system(size: 13, weight: .semibold, design: .rounded))
                             .foregroundStyle(AppTheme.textSecondary)
+
+                        TextField("First name", text: $firstName)
+                            .focused($focusedField, equals: .firstName)
+                            .textContentType(.givenName)
+                            .autocorrectionDisabled(true)
+                            .submitLabel(.next)
+                            .onSubmit { focusedField = .email }
+                            .modifier(AuthTextFieldStyle())
 
                         TextField("Email", text: $email)
                             .focused($focusedField, equals: .email)
@@ -576,25 +631,63 @@ private struct EmailSignUpView: View {
                                 }
                             }
 
-                        if emailCheckState == .taken {
-                            Text("This email is taken.")
-                                .font(.footnote)
-                                .foregroundStyle(.red)
+                        ZStack {
+                            if showPassword {
+                                TextField("Password", text: $password)
+                                    .focused($focusedField, equals: .password)
+                                    .textContentType(.newPassword)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled(true)
+                                    .submitLabel(.next)
+                                    .onSubmit { focusedField = .confirm }
+                            } else {
+                                SecureField("Password", text: $password)
+                                    .focused($focusedField, equals: .password)
+                                    .textContentType(.newPassword)
+                                    .submitLabel(.next)
+                                    .onSubmit { focusedField = .confirm }
+                            }
+                        }
+                        .modifier(AuthTextFieldStyle())
+                        .overlay(alignment: .trailing) {
+                            Button {
+                                showPassword.toggle()
+                            } label: {
+                                Image(systemName: showPassword ? "eye.slash" : "eye")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(AppTheme.textSecondary)
+                            }
+                            .padding(.trailing, 14)
                         }
 
-                        SecureField("Password", text: $password)
-                            .focused($focusedField, equals: .password)
-                            .textContentType(.newPassword)
-                            .submitLabel(.next)
-                            .onSubmit { focusedField = .confirm }
-                            .modifier(AuthTextFieldStyle())
-
-                        SecureField("Confirm password", text: $confirmPassword)
-                            .focused($focusedField, equals: .confirm)
-                            .textContentType(.newPassword)
-                            .submitLabel(.go)
-                            .onSubmit { if canSubmit { submit() } }
-                            .modifier(AuthTextFieldStyle())
+                        ZStack {
+                            if showConfirmPassword {
+                                TextField("Confirm password", text: $confirmPassword)
+                                    .focused($focusedField, equals: .confirm)
+                                    .textContentType(.newPassword)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled(true)
+                                    .submitLabel(.go)
+                                    .onSubmit { if canSubmit { submit() } }
+                            } else {
+                                SecureField("Confirm password", text: $confirmPassword)
+                                    .focused($focusedField, equals: .confirm)
+                                    .textContentType(.newPassword)
+                                    .submitLabel(.go)
+                                    .onSubmit { if canSubmit { submit() } }
+                            }
+                        }
+                        .modifier(AuthTextFieldStyle())
+                        .overlay(alignment: .trailing) {
+                            Button {
+                                showConfirmPassword.toggle()
+                            } label: {
+                                Image(systemName: showConfirmPassword ? "eye.slash" : "eye")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(AppTheme.textSecondary)
+                            }
+                            .padding(.trailing, 14)
+                        }
                     }
                     .padding(16)
                     .modifier(AuthPanelCardStyle())
@@ -609,6 +702,7 @@ private struct EmailSignUpView: View {
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
+                        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
                     .buttonStyle(.plain)
                     .modifier(AuthPrimaryButtonStyle())
@@ -693,7 +787,7 @@ private struct EmailSignUpView: View {
 
         isSubmitting = true
         Task {
-            let outcome = await authService.signUp(fullName: nil, email: e, password: password)
+            let outcome = await authService.signUp(fullName: trimmedFirstName, email: e, password: password)
             await MainActor.run {
                 isSubmitting = false
                 if authService.isAuthenticated {
@@ -704,7 +798,7 @@ private struct EmailSignUpView: View {
                 case .signedIn:
                     break
                 case .needsEmailConfirmation:
-                    showToast("Check your email and tap the confirmation link to continue onboarding.")
+                    showToast("We sent a confirmation link to your email. Tap it to get started!")
                 case .emailAlreadyExists:
                     emailCheckState = .taken
                     showToast(authService.lastAuthError ?? "An account with this email already exists. Try a different one or log in.")
@@ -736,6 +830,7 @@ private struct EmailSignUpView: View {
                 await MainActor.run {
                     guard normalizeEmail(email) == emailToCheck else { return }
                     emailCheckState = exists ? .taken : .available
+                    if exists { showToast("This email is taken.") }
                 }
             } catch {
                 guard !Task.isCancelled else { return }

--- a/TalkToMe/Chat/Controllers/ChatStreamingController.swift
+++ b/TalkToMe/Chat/Controllers/ChatStreamingController.swift
@@ -4,6 +4,7 @@ import UIKit
 @MainActor
 protocol ChatStreamingDelegate: AnyObject {
     var inputText: String { get set }
+    var replyQuoteText: String? { get set }
     var messages: [ChatMessage] { get set }
     var pendingAttachments: [PendingAttachment] { get set }
     var sessionId: UUID? { get set }
@@ -84,6 +85,17 @@ final class ChatStreamingController {
         currentStreamToken = nil
     }
 
+    /// Prefer the actively speaking voice agent; otherwise use the currently selected buddy name.
+    /// This lets partner draft segments carry stable `ghost_name` metadata in normal (non-speak) chat, too.
+    private func resolvedGhostNameForRequest() -> String? {
+        let active = (activeVoiceAgentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !active.isEmpty { return active }
+
+        let selected = (UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return selected.isEmpty ? nil : selected
+    }
+
     func getAssistantMessageId(for sessionId: UUID) -> UUID? {
         assistantMessageIdBySession[sessionId]
     }
@@ -105,14 +117,30 @@ final class ChatStreamingController {
     }
 
     func sendMessage(overrideText: String? = nil, isRegeneration: Bool = false, reuseMessageId: UUID? = nil) {
-        guard let delegate else { return }
+        guard let delegate else {
+            print("[VoiceAgent] sendMessage — no delegate, returning")
+            return
+        }
 
         let trimmedMessage = (overrideText ?? delegate.inputText).trimmingCharacters(in: .whitespacesAndNewlines)
         let attachmentsToSend = delegate.pendingAttachments
-        guard !(trimmedMessage.isEmpty && attachmentsToSend.isEmpty) else { return }
-        guard !isStreaming else { return }
+        guard !(trimmedMessage.isEmpty && attachmentsToSend.isEmpty) else {
+            if activeVoiceAgentName != nil { print("[VoiceAgent] sendMessage — empty message & no attachments, returning") }
+            return
+        }
+        guard !isStreaming else {
+            if activeVoiceAgentName != nil { print("[VoiceAgent] sendMessage — already streaming, returning") }
+            return
+        }
 
-        let messageToSend = trimmedMessage
+        let quoteText = delegate.replyQuoteText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasQuote = !(quoteText ?? "").isEmpty
+        let messageToSend: String = {
+            if hasQuote, let qt = quoteText {
+                return "> \(qt)\n\n\(trimmedMessage)"
+            }
+            return trimmedMessage
+        }()
         let previewToSend: String = {
             if !trimmedMessage.isEmpty { return trimmedMessage }
             if attachmentsToSend.contains(where: { $0.isImage }) { return "Sent a photo." }
@@ -158,6 +186,9 @@ final class ChatStreamingController {
 
         var outboxAttachments: [OutboxAttachment] = []
         var segs: [[String: Any]] = []
+        if hasQuote, let qt = quoteText {
+            segs.append(["type": "quoted_reply", "text": qt])
+        }
         if !trimmedMessage.isEmpty {
             segs.append(["type": "text", "content": trimmedMessage])
         }
@@ -207,10 +238,10 @@ final class ChatStreamingController {
 
         if !isRegeneration {
             let persistedContent: String = {
-                guard !attachmentsToSend.isEmpty else { return messageToSend }
+                guard !attachmentsToSend.isEmpty || hasQuote else { return trimmedMessage }
                 let obj: [String: Any] = ["_talktome": ["type": "segments", "segments": segs]]
                 let data = (try? JSONSerialization.data(withJSONObject: obj)) ?? Data()
-                return String(data: data, encoding: .utf8) ?? messageToSend
+                return String(data: data, encoding: .utf8) ?? trimmedMessage
             }()
 
             let dto = BackendService.ChatMessageDTO(
@@ -245,6 +276,7 @@ final class ChatStreamingController {
             NotificationCenter.default.post(name: .chatSessionsNeedRefresh, object: nil)
 
             delegate.inputText = ""
+            delegate.replyQuoteText = nil
             delegate.pendingAttachments = []
         } else {
             // Regeneration: persist the user message to local DB (the old one
@@ -749,6 +781,7 @@ final class ChatStreamingController {
                         }
                     }
                 case .done:
+                    print("[VoiceAgent] SSE .done received — voiceAgent=\(voiceAgentToSend ?? "nil") accumulatedLen=\(accumulated.count)")
                     let targetSid = streamSessionId ?? delegate.sessionId
                     if let sid = targetSid, sid != delegate.sessionId {
                         Task { @MainActor in
@@ -823,12 +856,16 @@ final class ChatStreamingController {
                                 // Previously this task slept 900ms, creating a window
                                 // where app termination could lose voice metadata.
                                 Task.detached {
-                                    // Skip server reconciliation after regeneration: the local
-                                    // DB already has the correct messages and reconciling risks
-                                    // restoring old messages that failed to delete on the server.
-                                    if !skipReconciliation,
-                                       let dtos = try? await BackendService.shared.fetchMessages(sessionId: sid, accessToken: tokenForSync) {
-                                        await ChatStore.shared.reconcileMessagesWithServer(dtos, sessionId: sid)
+                                    if let dtos = try? await BackendService.shared.fetchMessages(sessionId: sid, accessToken: tokenForSync) {
+                                        if skipReconciliation {
+                                            // After regeneration: upsert server messages so the new
+                                            // assistant message is persisted to GRDB, but skip orphan
+                                            // cleanup to avoid restoring messages pending server-side
+                                            // deletion.
+                                            await ChatStore.shared.upsertMessages(dtos)
+                                        } else {
+                                            await ChatStore.shared.reconcileMessagesWithServer(dtos, sessionId: sid)
+                                        }
                                     }
                                     if let ghostName = capturedGhostName {
                                         await ChatStore.shared.setGhostNameForPartnerDrafts(sessionId: sid, ghostName: ghostName)
@@ -857,6 +894,7 @@ final class ChatStreamingController {
                         }
                     }
                 case .error(let message):
+                    print("[VoiceAgent] SSE .error received: \(message) — voiceAgent=\(voiceAgentToSend ?? "nil")")
                     if message.contains("previous_response_not_found") || (message.contains("previous_response_id") && message.contains("not found")) {
                         Task { @MainActor in
                             let sid = streamSessionId ?? localSessionIdForSend
@@ -925,16 +963,16 @@ final class ChatStreamingController {
                 }
             }
 
-            let ghostNameToSend: String? = {
-                let trimmed = (self.activeVoiceAgentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                return trimmed.isEmpty ? nil : trimmed
-            }()
+            let ghostNameToSend: String? = self.resolvedGhostNameForRequest()
             let cleanedGhostName = ghostNameToSend?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !cleanedGhostName.isEmpty {
                 self.ghostNameBySession[localSessionIdForSend] = cleanedGhostName
             }
 
             let deleteBeforeId: UUID? = isRegeneration ? reuseMessageId : nil
+            if voiceAgentToSend != nil {
+                print("[VoiceAgent] starting SSE stream — voiceAgent=\(voiceAgentToSend!) ghostName=\(ghostNameToSend ?? "nil") sessionId=\(requestSessionIdForStream?.uuidString ?? "nil") customInstructions=\(customInstructionsToSend != nil ? "yes" : "no")")
+            }
             let task = Task.detached { [streamToken] in
                 let stream = BackendService.shared.streamChatMessage(
                     messageToSend,

--- a/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
+++ b/TalkToMe/Chat/Controllers/ChatVoiceModeController.swift
@@ -116,14 +116,20 @@ final class ChatVoiceModeController: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] transcript in
                 guard let self else { return }
-                guard self.isSpeakModeActive else { return }
+                guard self.isSpeakModeActive else {
+                    print("[VoiceAgent] lastFinalUtterance received but speak mode inactive, ignoring")
+                    return
+                }
                 let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { return }
+
+                print("[VoiceAgent] lastFinalUtterance: \"\(trimmed.prefix(80))\" — isStreaming=\(isStreamingCheck()) ttsIsSpeaking=\(elevenLabsStreamingTTS.isSpeaking) isLoading=\(delegate?.isLoading ?? false)")
 
                 isSpeakComposerLocked = true
 
                 // If the assistant is currently answering, stop it (barge-in).
                 if isStreamingCheck() || elevenLabsStreamingTTS.isSpeaking || (delegate?.isLoading == true) {
+                    print("[VoiceAgent] barge-in: stopping current generation & TTS")
                     streamingController?.stopGeneration()
                     elevenLabsStreamingTTS.cancel()
                 }
@@ -134,7 +140,11 @@ final class ChatVoiceModeController: ObservableObject {
                 pendingSpeakAutoSendTask = Task { @MainActor [weak self] in
                     guard let self else { return }
                     try? await Task.sleep(nanoseconds: 60_000_000) // 60ms
-                    guard self.isSpeakModeActive else { return }
+                    guard self.isSpeakModeActive else {
+                        print("[VoiceAgent] speak mode became inactive before auto-send, aborting")
+                        return
+                    }
+                    print("[VoiceAgent] auto-sending message: \"\(trimmed.prefix(80))\"")
                     self.streamingController?.sendMessage(overrideText: trimmed)
                     self.isSpeakComposerLocked = false
                 }
@@ -158,6 +168,7 @@ final class ChatVoiceModeController: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] speaking in
                 guard let self else { return }
+                print("[VoiceAgent] TTS isSpeaking changed to \(speaking) — isSpeakModeActive=\(self.isSpeakModeActive) phase=\(self.speakModePhase) isStreaming=\(self.isStreamingCheck()) sttConnected=\(self.speakSTTService.isConnected) sttRecording=\(self.speakSTTService.isRecording)")
                 guard self.isSpeakModeActive else { return }
 
                 if speaking {
@@ -172,6 +183,8 @@ final class ChatVoiceModeController: ObservableObject {
                     if self.speakModePhase == .answering {
                         if !self.isStreamingCheck() {
                             self.updatePhase(.listening)
+                        } else {
+                            print("[VoiceAgent] TTS stopped but still streaming, staying in .answering")
                         }
                     }
                 }
@@ -219,10 +232,13 @@ final class ChatVoiceModeController: ObservableObject {
 
     private func updatePhase(_ newPhase: SpeakModePhase) {
         guard speakModePhase != newPhase else { return }
+        let oldPhase = speakModePhase
         speakModePhase = newPhase
+        print("[VoiceAgent] phase: \(oldPhase) → \(newPhase)")
     }
 
     func notifyStreamingStarted() {
+        print("[VoiceAgent] notifyStreamingStarted — isSpeakModeActive=\(isSpeakModeActive) phase=\(speakModePhase)")
         guard isSpeakModeActive else { return }
         if speakModePhase == .processing {
             updatePhase(.answering)
@@ -230,6 +246,7 @@ final class ChatVoiceModeController: ObservableObject {
     }
 
     func notifyStreamingFinished() {
+        print("[VoiceAgent] notifyStreamingFinished — isSpeakModeActive=\(isSpeakModeActive) phase=\(speakModePhase) ttsIsSpeaking=\(elevenLabsStreamingTTS.isSpeaking) ttsIsConnected=\(elevenLabsStreamingTTS.isConnected) sttIsConnected=\(speakSTTService.isConnected) sttIsRecording=\(speakSTTService.isRecording)")
         guard isSpeakModeActive else { return }
         if !elevenLabsStreamingTTS.isSpeaking && speakModePhase == .answering {
             updatePhase(.listening)
@@ -407,6 +424,9 @@ final class ChatVoiceModeController: ObservableObject {
     }
 
     func stopSpeakMode() {
+        print("[VoiceAgent] stopSpeakMode() called — phase=\(speakModePhase) ttsIsSpeaking=\(elevenLabsStreamingTTS.isSpeaking) ttsConnected=\(elevenLabsStreamingTTS.isConnected) sttConnected=\(speakSTTService.isConnected) sttRecording=\(speakSTTService.isRecording)")
+        // Capture a stack trace to identify who is calling stopSpeakMode
+        Thread.callStackSymbols.prefix(10).forEach { print("[VoiceAgent] stopSpeakMode caller: \($0)") }
         isSpeakModeActive = false
         isSpeakMicMuted = false
         isSpeakComposerLocked = false

--- a/TalkToMe/Chat/Models/ChatMessage.swift
+++ b/TalkToMe/Chat/Models/ChatMessage.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum MessageSegment: Equatable {
     case text(String)
+    case quotedReply(String)
     case partnerMessage(text: String, ghostName: String?)
     case partnerReceived(String)
     case imageData(Data)
@@ -93,6 +94,10 @@ struct ChatMessage: Identifiable {
                     case "text":
                         if let c = dict["content"] as? String, !c.isEmpty {
                             segs.append(.text(c))
+                        }
+                    case "quoted_reply":
+                        if let txt = dict["text"] as? String, !txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            segs.append(.quotedReply(txt))
                         }
                     case "image":
                         if let url = dict["url"] as? String, !url.isEmpty {

--- a/TalkToMe/Chat/ViewModels/ChatViewModel.swift
+++ b/TalkToMe/Chat/ViewModels/ChatViewModel.swift
@@ -20,6 +20,7 @@ class ChatViewModel: ObservableObject {
             }
         }
     }
+    @Published var replyQuoteText: String? = nil
     @Published var isLoading: Bool = false
     @Published var isLoadingHistory: Bool = false
     @Published var isAssistantTyping: Bool = false
@@ -396,6 +397,7 @@ extension ChatViewModel: ChatStreamingDelegate {
     }
 
     func streamingWillStart() {
+        print("[VoiceAgent] streamingWillStart — isSpeakModeActive=\(isSpeakModeActive)")
         didReceiveFirstToken = false
         hasSpokenCurrentResponse = false
         hasActiveStreamingCycle = true
@@ -408,16 +410,22 @@ extension ChatViewModel: ChatStreamingDelegate {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let voiceName = (voiceController.capturedVoiceName ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !voiceId.isEmpty else { return }
+        guard !voiceId.isEmpty else {
+            print("[VoiceAgent] streamingWillStart — no voiceId, skipping TTS start")
+            return
+        }
 
+        print("[VoiceAgent] streamingWillStart — starting TTS with voiceId=\(voiceId) voiceName=\(voiceName)")
         Task { @MainActor in
             await elevenLabsStreamingTTS.start(voiceId: voiceId, voiceName: voiceName)
+            print("[VoiceAgent] TTS start() completed — isConnected=\(elevenLabsStreamingTTS.isConnected) lastError=\(elevenLabsStreamingTTS.lastError ?? "nil")")
         }
     }
 
     func streamingDidReceiveToken(_ token: String) {
         if !didReceiveFirstToken {
             didReceiveFirstToken = true
+            print("[VoiceAgent] first token received — isSpeakModeActive=\(isSpeakModeActive) ttsConnected=\(elevenLabsStreamingTTS.isConnected)")
             voiceController.notifyStreamingStarted()
         }
 
@@ -429,10 +437,12 @@ extension ChatViewModel: ChatStreamingDelegate {
     }
 
     func streamingDidFinish() {
+        print("[VoiceAgent] streamingDidFinish — isSpeakModeActive=\(isSpeakModeActive) ttsIsSpeaking=\(elevenLabsStreamingTTS.isSpeaking) ttsConnected=\(elevenLabsStreamingTTS.isConnected) spokenTextLen=\(elevenLabsStreamingTTS.recentlySpokenText.count)")
         voiceController.notifyStreamingFinished()
 
         guard isSpeakModeActive else { return }
         // Always call finish — it will wait for connection if needed
+        print("[VoiceAgent] calling TTS finish()")
         elevenLabsStreamingTTS.finish()
     }
 

--- a/TalkToMe/Chat/Views/ChatScreenView.swift
+++ b/TalkToMe/Chat/Views/ChatScreenView.swift
@@ -62,6 +62,7 @@ struct ChatScreenView: View {
           chatViewModel.voiceController.toggleSpeakMicMute()
         },
         inputText: $chatViewModel.inputText,
+        replyQuoteText: $chatViewModel.replyQuoteText,
         isLoading: $chatViewModel.isLoading,
         pendingAttachments: Binding(
           get: { chatViewModel.pendingAttachments },

--- a/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
+++ b/TalkToMe/Chat/Views/Components/BuddyHeaderView.swift
@@ -105,13 +105,13 @@ struct BuddyHeaderView: View {
         case .answering:
             HStack(spacing: 4) {
                 Circle()
-                    .fill(.green)
+                    .fill(.blue)
                     .frame(width: 6, height: 6)
                 Text("Speaking")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(.secondary)
             }
-        case .listening:
+        case .listening, .processing:
             HStack(spacing: 4) {
                 Circle()
                     .fill(.yellow)
@@ -121,7 +121,7 @@ struct BuddyHeaderView: View {
                     .foregroundColor(.secondary)
             }
         default:
-            // For .idle, .connecting, .processing — show the description instead
+            // For .idle and .connecting — show the description instead
             if !buddyDescription.isEmpty {
                 Text(buddyDescription)
                     .font(.system(size: 11, weight: .medium))

--- a/TalkToMe/Chat/Views/Components/ChatSessionActionsModifier.swift
+++ b/TalkToMe/Chat/Views/Components/ChatSessionActionsModifier.swift
@@ -87,6 +87,8 @@ struct ChatSessionActionsMenu: View {
     let onDeleteRequest: () -> Void
     let onReportRequest: () -> Void
 
+    @State private var showActions: Bool = false
+
     private var formattedTitle: String {
         let words = currentTitle.split(separator: " ")
         guard words.count > 2 else { return currentTitle }
@@ -96,35 +98,37 @@ struct ChatSessionActionsMenu: View {
     }
 
     var body: some View {
-        Menu {
-            Section {
-                Button("Rename", systemImage: "pencil") {
-                    guard sessionId != nil else { return }
-                    onRenameRequest()
-                }
-                .disabled(sessionId == nil)
-
-                Button("Report", systemImage: "exclamationmark.bubble") {
-                    onReportRequest()
-                }
-                .disabled(sessionId == nil)
-
-                Button("Archive", systemImage: "archivebox") {
-                    onArchiveRequest()
-                }
-                .disabled(sessionId == nil)
-
-                Button("Delete", systemImage: "trash", role: .destructive) {
-                    onDeleteRequest()
-                }
-                .disabled(sessionId == nil)
-            } header: {
-                Text(formattedTitle)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-            }
+        Button {
+            // Dismiss keyboard first so it doesn't interfere with the action sheet
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil, from: nil, for: nil
+            )
+            showActions = true
         } label: {
             Label("More", systemImage: "ellipsis")
+        }
+        .confirmationDialog(formattedTitle, isPresented: $showActions, titleVisibility: .visible) {
+            Button("Rename") {
+                guard sessionId != nil else { return }
+                onRenameRequest()
+            }
+            .disabled(sessionId == nil)
+
+            Button("Report") {
+                onReportRequest()
+            }
+            .disabled(sessionId == nil)
+
+            Button("Archive") {
+                onArchiveRequest()
+            }
+            .disabled(sessionId == nil)
+
+            Button("Delete", role: .destructive) {
+                onDeleteRequest()
+            }
+            .disabled(sessionId == nil)
         }
     }
 }

--- a/TalkToMe/Chat/Views/Components/FriendPickerSheetView.swift
+++ b/TalkToMe/Chat/Views/Components/FriendPickerSheetView.swift
@@ -83,7 +83,7 @@ struct FriendPickerSheetView: View {
                             } label: {
                                 HStack {
                                     ZStack(alignment: .bottomTrailing) {
-                                        SidebarAvatarView(avatarURL: friend.avatarURL)
+                                        SidebarAvatarView(avatarURL: friend.avatarURL, name: friend.fullName)
                                             .frame(width: 34, height: 34)
                                             .clipShape(Circle())
 

--- a/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
+++ b/TalkToMe/Chat/Views/Components/MessageBubbleView.swift
@@ -14,24 +14,36 @@ struct UserMessageBubbleView: View {
     let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     let attachmentSegments = segments.filter { isAttachmentSegment($0) }
 
+    let quoteText = segments.compactMap { seg -> String? in
+      if case .quotedReply(let t) = seg { return t }
+      return nil
+    }.first
+
     VStack(alignment: .trailing, spacing: 8) {
       if !attachmentSegments.isEmpty {
         attachmentsView(segments: attachmentSegments, alignment: .trailing)
       }
-      if hasText {
-        Text(text)
-          .font(.system(size: 17 * fontSizeScale, weight: .regular))
-          .italic(isFromVoiceMode)
-          .lineSpacing(2)
-          .padding(.horizontal, 16)
-          .padding(.vertical, 14)
-          .background(
-            RoundedRectangle(cornerRadius: 20)
-              .fill(userBubbleGradient)
-          )
-          .foregroundColor(AppTheme.talkToMePrimaryText)
-          .textSelection(.enabled)
-          .frame(maxWidth: 320, alignment: .trailing)
+      if quoteText != nil || hasText {
+        VStack(alignment: .leading, spacing: quoteText != nil && hasText ? 6 : 0) {
+          if let quoteText {
+            QuotedReplyView(text: quoteText)
+          }
+          if hasText {
+            Text(text)
+              .font(.system(size: 17 * fontSizeScale, weight: .regular))
+              .italic(isFromVoiceMode)
+              .lineSpacing(2)
+          }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+          RoundedRectangle(cornerRadius: 20)
+            .fill(userBubbleGradient)
+        )
+        .foregroundColor(AppTheme.talkToMePrimaryText)
+        .textSelection(.enabled)
+        .frame(maxWidth: 320, alignment: .trailing)
       }
     }
     .fullScreenCover(
@@ -349,6 +361,7 @@ extension View {
 struct MessageBubbleView: View {
 
   @ObservedObject var chatViewModel: ChatViewModel
+  @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var selectedVoiceName: String = ""
 
   let message: ChatMessage
 
@@ -395,6 +408,12 @@ struct MessageBubbleView: View {
     return true
   }
 
+  private var buddyDisplayName: String {
+    let name = selectedVoiceName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty else { return "Buddy" }
+    return name.prefix(1).uppercased() + name.dropFirst().lowercased()
+  }
+
   private var hasRenderableAssistantContent: Bool {
     if message.isToolLoading { return true }
     return message.segments.contains { segment in
@@ -407,6 +426,8 @@ struct MessageBubbleView: View {
         return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       case .imageData(_), .imageURL(_), .fileData(_, _), .fileURL(_, _):
         return true
+      case .quotedReply:
+        return false
       }
     }
   }
@@ -506,7 +527,11 @@ struct MessageBubbleView: View {
       } else if message.isFromPartnerUser {
         PartnerMessageBlockView(
           text: plainText(from: message.segments),
-          senderUserId: message.senderUserId
+          senderUserId: message.senderUserId,
+          timestamp: message.timestamp,
+          onReply: { selectedText in
+            chatViewModel.replyQuoteText = selectedText
+          }
         )
       } else if shouldShowThinkingIndicator || hasRenderableAssistantContent {
         let hasTextContent = shouldShowThinkingIndicator || message.isToolLoading
@@ -543,10 +568,23 @@ struct MessageBubbleView: View {
                   case .text(let text):
                     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !trimmed.isEmpty {
-                      MarkdownRendererView(markdown: text, isStreaming: isActivelyStreamingMessage)
+                      if isActivelyStreamingMessage {
+                        MarkdownRendererView(markdown: text, isStreaming: true)
+                          .frame(maxWidth: .infinity, alignment: .leading)
+                          .padding(.horizontal, 4)
+                          .padding(.vertical, 4)
+                      } else {
+                        SelectableTextView(
+                          attributedText: Self.markdownToNSAttributedString(text),
+                          replyToName: buddyDisplayName,
+                          onReply: { selectedText in
+                            chatViewModel.replyQuoteText = selectedText
+                          }
+                        )
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 4)
                         .padding(.vertical, 4)
+                      }
                     }
                   default:
                     EmptyView()
@@ -606,7 +644,10 @@ struct MessageBubbleView: View {
                   isSent: isSent,
                   isLinked: isLinked,
                   recipientUserId: chatViewModel.selectedFriendUserId,
-                  ghostName: ghostName ?? message.ghostName
+                  ghostName: ghostName ?? message.ghostName,
+                  onReply: { selectedText in
+                    chatViewModel.replyQuoteText = selectedText
+                  }
                 ) { action in
                   switch action {
                   case .send(let edited):
@@ -617,7 +658,14 @@ struct MessageBubbleView: View {
               }
             case .partnerReceived(let text):
               if !text.isEmpty {
-                PartnerMessageBlockView(text: text, senderUserId: message.senderUserId)
+                PartnerMessageBlockView(
+                  text: text,
+                  senderUserId: message.senderUserId,
+                  timestamp: message.timestamp,
+                  onReply: { selectedText in
+                    chatViewModel.replyQuoteText = selectedText
+                  }
+                )
                   .id("partner_received_\(text.hashValue)")
               }
             default:
@@ -643,6 +691,34 @@ struct MessageBubbleView: View {
       if case .text(let text) = segment { return text }
       return nil
     }.joined()
+  }
+
+  /// Convert markdown text to NSAttributedString for use in SelectableTextView.
+  static func markdownToNSAttributedString(_ markdown: String) -> NSAttributedString {
+    let fontSize: CGFloat = 17
+    let textColor = UIColor { trait in
+      trait.userInterfaceStyle == .dark ? UIColor(white: 0.96, alpha: 1) : UIColor(white: 0.06, alpha: 1)
+    }
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.lineSpacing = 2
+
+    let baseAttributes: [NSAttributedString.Key: Any] = [
+      .font: UIFont.systemFont(ofSize: fontSize),
+      .foregroundColor: textColor,
+      .paragraphStyle: paragraphStyle,
+    ]
+
+    // Try to parse markdown into NSAttributedString
+    if let attrStr = try? NSAttributedString(
+      markdown: markdown,
+      options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+    ) {
+      let mutable = NSMutableAttributedString(attributedString: attrStr)
+      mutable.addAttributes(baseAttributes, range: NSRange(location: 0, length: mutable.length))
+      return mutable
+    }
+
+    return NSAttributedString(string: markdown, attributes: baseAttributes)
   }
 
   @ViewBuilder

--- a/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerDraftBlockView.swift
@@ -4,11 +4,12 @@ struct PartnerDraftBlockView: View {
 
     enum Action { case send(String) }
 
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var friendsViewModel: FriendsViewModel
-    @AppStorage(PreferenceKeys.elevenLabsVoiceName) private var currentBuddyName: String = ""
     @AppStorage(PreferenceKeys.fontSizePreference) private var fontSizeScale: Double = 1.0
 
     @State private var text: String
+    @State private var fallbackBuddyName: String
     @State private var isConfirmingNormalSend: Bool = false
     @State private var showSentLocally: Bool = false
     @State private var showFriendMenu: Bool = false
@@ -21,6 +22,7 @@ struct PartnerDraftBlockView: View {
     let isLinked: Bool
     let recipientUserId: UUID?
     let ghostName: String?
+    var onReply: ((String) -> Void)? = nil
     let onAction: (Action) -> Void
 
     init(
@@ -29,32 +31,39 @@ struct PartnerDraftBlockView: View {
         isLinked: Bool = true,
         recipientUserId: UUID?,
         ghostName: String? = nil,
+        onReply: ((String) -> Void)? = nil,
         onAction: @escaping (Action) -> Void
     ) {
+        let selectedBuddy = (UserDefaults.standard.string(forKey: PreferenceKeys.elevenLabsVoiceName) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         self.initialText = initialText
         self.isSent = isSent
         self.isLinked = isLinked
         self.recipientUserId = recipientUserId
         self.ghostName = ghostName
+        self.onReply = onReply
         self._text = State(initialValue: initialText)
+        self._fallbackBuddyName = State(initialValue: selectedBuddy)
         self.onAction = onAction
     }
 
-    /// Use the persisted ghost name if available, otherwise fall back to the currently selected buddy.
-    private var effectiveBuddyName: String {
+    /// Prefer persisted metadata; if missing, keep a one-time fallback snapshot so labels don't
+    /// mutate when the user switches buddies later.
+    private var effectiveBuddyName: String? {
         if let gn = ghostName, !gn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return gn
         }
-        return currentBuddyName
+        let fallback = fallbackBuddyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return fallback.isEmpty ? nil : fallback
     }
 
     private var resolvedBuddyName: String {
-        let name = effectiveBuddyName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.isEmpty ? "Your buddy" : name
+        effectiveBuddyName ?? "Your buddy"
     }
 
     private var buddyImage: UIImage? {
-        ElevenLabsVoiceSuggestionsView.ghostUIImage(for: effectiveBuddyName)
+        guard let buddyName = effectiveBuddyName else { return nil }
+        return ElevenLabsVoiceSuggestionsView.ghostUIImage(for: buddyName)
     }
 
     private var recipientFirstName: String {
@@ -68,103 +77,121 @@ struct PartnerDraftBlockView: View {
         isSent || showSentLocally
     }
 
+    private var bubbleColor: Color {
+        colorScheme == .light
+            ? Color.talkToMePartnerBubbleLightGray
+            : AppTheme.talkToMeBubbleAI
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Buddy header
-            HStack(spacing: 5) {
+        VStack(alignment: .leading, spacing: 4) {
+            // Name · "drafted this" above the bubble
+            HStack(spacing: 4) {
+                Text(resolvedBuddyName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.primary)
+                Text("drafted this")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(AppTheme.brand)
+            }
+            .padding(.leading, 61)
+
+            HStack(alignment: .bottom, spacing: 6) {
+                // Buddy avatar
                 Group {
                     if let uiImage = buddyImage {
                         Image(uiImage: uiImage)
                             .resizable()
                             .scaledToFill()
-                            .frame(width: 26, height: 26)
-                            .clipShape(Circle())
                     } else {
                         Circle()
-                            .fill(Color(.systemGray5))
-                            .frame(width: 26, height: 26)
+                            .fill(Color(.tertiarySystemFill))
                     }
                 }
-                .offset(y: -1)
+                .frame(width: 43, height: 43)
+                .clipShape(Circle())
 
-                HStack(spacing: 4) {
-                    Text(resolvedBuddyName)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.primary)
+                // Bubble content
+                VStack(alignment: .leading, spacing: 0) {
+                    // Message body
+                    Group {
+                        if let onReply, !text.isEmpty {
+                            SelectableTextView(
+                                attributedText: partnerDraftNSAttributedString(text),
+                                replyToName: resolvedBuddyName,
+                                onReply: onReply
+                            )
+                        } else {
+                            Text(text.isEmpty ? " " : text)
+                                .font(.system(size: 16.5 * fontSizeScale))
+                                .foregroundColor(.primary)
+                                .multilineTextAlignment(.leading)
+                                .lineSpacing(3)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                    .padding(.vertical, 2)
+                    .padding(.bottom, 14)
 
-                    Text("drafted this")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.secondary)
+                    // Send / unsend button row
+                    HStack(spacing: 10) {
+                        if isConfirmingNormalSend {
+                            Button(action: {
+                                Haptics.impact(.light)
+                                withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
+                                    isConfirmingNormalSend = false
+                                }
+                            }) {
+                                Text("Cancel")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .transition(.scale.combined(with: .opacity))
+                        }
+
+                        if alreadySent {
+                            Button {
+                                Haptics.impact(.light)
+                                handleUnsend()
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "arrow.uturn.backward")
+                                        .font(.system(size: 11, weight: .semibold))
+                                    Text("Unsend")
+                                        .font(.system(size: 13, weight: .medium))
+                                }
+                                .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .transition(.scale.combined(with: .opacity))
+                        }
+
+                        Spacer()
+
+                        Button(action: handleButtonTap) {
+                            sendButtonContent
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(alreadySent)
+                    }
+
+                    // Inline friend picker menu
+                    if showFriendMenu {
+                        friendAvatarPicker
+                            .transition(.opacity)
+                    }
                 }
-
-                Spacer()
-            }
-            .padding(.bottom, 10)
-
-            // Message body
-            Text(text.isEmpty ? " " : text)
-                .font(.system(size: 16.5 * fontSizeScale))
-                .foregroundColor(.primary)
-                .multilineTextAlignment(.leading)
-                .lineSpacing(3)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
-                .padding(.bottom, 14)
-
-            // Send / unsend button row
-            HStack(spacing: 10) {
-                if isConfirmingNormalSend {
-                    Button(action: {
-                        Haptics.impact(.light)
-                        withAnimation(.spring(response: 0.22, dampingFraction: 0.9)) {
-                            isConfirmingNormalSend = false
-                        }
-                    }) {
-                        Text("Cancel")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .transition(.scale.combined(with: .opacity))
-                }
-
-                if alreadySent {
-                    Button {
-                        Haptics.impact(.light)
-                        handleUnsend()
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.uturn.backward")
-                                .font(.system(size: 11, weight: .semibold))
-                            Text("Unsend")
-                                .font(.system(size: 13, weight: .medium))
-                        }
-                        .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .transition(.scale.combined(with: .opacity))
-                }
-
-                Spacer()
-
-                Button(action: handleButtonTap) {
-                    sendButtonContent
-                }
-                .buttonStyle(.plain)
-                .disabled(alreadySent)
-            }
-
-            // Inline friend picker menu
-            if showFriendMenu {
-                friendAvatarPicker
-                    .transition(.opacity)
+                .padding(10)
+                .background(
+                    PartnerDraftBubbleShape()
+                        .fill(bubbleColor)
+                )
             }
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(.ultraThinMaterial)
-        )
+        .padding(.bottom, 2)
         .onAppear {
             isConfirmingNormalSend = false
             showSentLocally = false
@@ -207,6 +234,17 @@ struct PartnerDraftBlockView: View {
         }
     }
 
+    private func partnerDraftNSAttributedString(_ text: String) -> NSAttributedString {
+        let fontSize: CGFloat = 16.5 * fontSizeScale
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 3
+        return NSAttributedString(string: text, attributes: [
+            .font: UIFont.systemFont(ofSize: fontSize),
+            .foregroundColor: UIColor.label,
+            .paragraphStyle: paragraphStyle,
+        ])
+    }
+
     // MARK: - Inline Friend Avatar Picker
 
     @ViewBuilder
@@ -229,7 +267,7 @@ struct PartnerDraftBlockView: View {
                     } label: {
                         VStack(spacing: 6) {
                             ZStack {
-                                SidebarAvatarView(avatarURL: friend.avatarURL)
+                                SidebarAvatarView(avatarURL: friend.avatarURL, name: friend.fullName)
                                     .frame(width: 44, height: 44)
                                     .clipShape(Circle())
                                     .overlay(
@@ -400,6 +438,11 @@ struct PartnerDraftBlockView: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 showFriendMenu.toggle()
             }
+            if showFriendMenu {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    NotificationCenter.default.post(name: .chatContentExpanded, object: nil)
+                }
+            }
             if friendsViewModel.friends.isEmpty {
                 Task { try? await friendsViewModel.loadFriends() }
             }
@@ -485,7 +528,7 @@ private struct SendToFriendSheetView: View {
                                 onPick(friend)
                             } label: {
                                 HStack(spacing: 12) {
-                                    SidebarAvatarView(avatarURL: friend.avatarURL)
+                                    SidebarAvatarView(avatarURL: friend.avatarURL, name: friend.fullName)
                                         .frame(width: 34, height: 34)
                                         .clipShape(Circle())
 
@@ -635,6 +678,35 @@ private struct AddFriendInlineView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             await friendsViewModel.refreshMyCode()
+        }
+    }
+}
+
+private struct PartnerDraftBubbleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let cr: CGFloat = 18
+        let tailExtent: CGFloat = 5
+
+        return Path { p in
+            p.move(to: CGPoint(x: cr, y: 0))
+            p.addLine(to: CGPoint(x: rect.width - cr, y: 0))
+            p.addArc(center: CGPoint(x: rect.width - cr, y: cr),
+                     radius: cr, startAngle: .degrees(-90), endAngle: .degrees(0), clockwise: false)
+            p.addLine(to: CGPoint(x: rect.width, y: rect.height - cr))
+            p.addArc(center: CGPoint(x: rect.width - cr, y: rect.height - cr),
+                     radius: cr, startAngle: .degrees(0), endAngle: .degrees(90), clockwise: false)
+            p.addLine(to: CGPoint(x: cr, y: rect.height))
+            p.addQuadCurve(
+                to: CGPoint(x: -tailExtent, y: rect.height - 1),
+                control: CGPoint(x: 4, y: rect.height + 3)
+            )
+            p.addQuadCurve(
+                to: CGPoint(x: 0, y: rect.height - cr * 1.2),
+                control: CGPoint(x: 0, y: rect.height - cr * 0.5)
+            )
+            p.addLine(to: CGPoint(x: 0, y: cr))
+            p.addArc(center: CGPoint(x: cr, y: cr),
+                     radius: cr, startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false)
         }
     }
 }

--- a/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
+++ b/TalkToMe/Chat/Views/Components/PartnerMessageBlockView.swift
@@ -2,13 +2,20 @@ import SwiftUI
 
 struct PartnerMessageBlockView: View {
 
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var friendsViewModel: FriendsViewModel
     @AppStorage(PreferenceKeys.fontSizePreference) private var fontSizeScale: Double = 1.0
 
     let text: String
     let senderUserId: UUID?
+    var timestamp: Date = Date()
+    var onReply: ((String) -> Void)? = nil
 
-    private let bubbleColor = Color(.secondarySystemBackground)
+    private var bubbleColor: Color {
+        colorScheme == .light
+            ? Color.talkToMePartnerBubbleLightGray
+            : AppTheme.talkToMeBubbleAI
+    }
 
     private var resolvedFriend: FriendSummary? {
         guard let senderUserId else { return nil }
@@ -29,36 +36,80 @@ struct PartnerMessageBlockView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var timeAgo: String {
+        let interval = Date().timeIntervalSince(timestamp)
+        if interval < 60 { return "now" }
+        let minutes = Int(interval / 60)
+        if minutes < 60 { return "\(minutes)m" }
+        let hours = minutes / 60
+        if hours < 24 { return "\(hours)h" }
+        let days = hours / 24
+        return "\(days)d"
+    }
+
     var body: some View {
-        HStack(alignment: .bottom, spacing: 6) {
-            AvatarCacheManager.shared.cachedAsyncImage(
-                urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
-                placeholder: avatarPlaceholder,
-                fallback: avatarPlaceholder
-            )
-            .frame(width: 43, height: 43)
-            .clipShape(Circle())
-
-            VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 4) {
+            // Name · time above the bubble
+            HStack(spacing: 4) {
                 Text(resolvedName)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.teal)
-
-                Text(text.isEmpty ? " " : text)
-                    .font(.system(size: 17 * fontSizeScale))
-                    .lineSpacing(2)
+                    .font(.system(size: 15, weight: .semibold))
                     .foregroundColor(.primary)
+                Text("·")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(Color(.tertiaryLabel))
+                Text(timeAgo)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(AppTheme.brand)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background {
-                PartnerBubbleShape()
-                    .fill(bubbleColor)
-            }
+            .padding(.leading, 61)
 
-            Spacer(minLength: 0)
+            HStack(alignment: .bottom, spacing: 6) {
+                AvatarCacheManager.shared.cachedAsyncImage(
+                    urlString: resolvedAvatarURL.isEmpty ? nil : resolvedAvatarURL,
+                    placeholder: avatarPlaceholder,
+                    fallback: avatarPlaceholder
+                )
+                .frame(width: 43, height: 43)
+                .clipShape(Circle())
+
+                Group {
+                    if let onReply, !text.isEmpty {
+                        SelectableTextView(
+                            attributedText: partnerNSAttributedString(text),
+                            replyToName: resolvedName,
+                            onReply: onReply
+                        )
+                        .padding(.horizontal, 2)
+                        .padding(.vertical, 2)
+                    } else {
+                        Text(text.isEmpty ? " " : text)
+                            .font(.system(size: 17 * fontSizeScale))
+                            .lineSpacing(2)
+                            .foregroundColor(.primary)
+                            .padding(.horizontal, 2)
+                            .padding(.vertical, 2)
+                    }
+                }
+                .padding(10)
+                .background {
+                    PartnerBubbleShape()
+                        .fill(bubbleColor)
+                }
+            }
         }
         .padding(.bottom, 2)
+    }
+
+    private func partnerNSAttributedString(_ text: String) -> NSAttributedString {
+        let fontSize: CGFloat = 17 * fontSizeScale
+        let textColor = UIColor.label
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 2
+        return NSAttributedString(string: text, attributes: [
+            .font: UIFont.systemFont(ofSize: fontSize),
+            .foregroundColor: textColor,
+            .paragraphStyle: paragraphStyle,
+        ])
     }
 
     private func avatarPlaceholder() -> AnyView {

--- a/TalkToMe/Chat/Views/Components/QuotedReplyView.swift
+++ b/TalkToMe/Chat/Views/Components/QuotedReplyView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Renders quoted/reply text inside a user message bubble.
+struct QuotedReplyView: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 1.5)
+                .fill(Color.white.opacity(0.5))
+                .frame(width: 3)
+
+            Text(text)
+                .font(.system(size: 14))
+                .foregroundColor(.white.opacity(0.7))
+                .italic()
+                .lineLimit(4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.bottom, 4)
+    }
+}

--- a/TalkToMe/Chat/Views/Components/SelectableTextView.swift
+++ b/TalkToMe/Chat/Views/Components/SelectableTextView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import UIKit
+
+/// A UIViewRepresentable that wraps a read-only UITextView with a custom "Reply"
+/// item in the native text selection menu. When the user selects text and taps Reply,
+/// the selected text is passed to the `onReply` callback.
+struct SelectableTextView: UIViewRepresentable {
+    let attributedText: NSAttributedString
+    var replyToName: String = "Reply"
+    let onReply: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onReply: onReply)
+    }
+
+    func makeUIView(context: Context) -> ReplyTextView {
+        let textView = ReplyTextView()
+        textView.replyMenuTitle = "Reply to \(replyToName)"
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.backgroundColor = .clear
+        textView.attributedText = attributedText
+        textView.dataDetectorTypes = .link
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.tintColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textView.setContentCompressionResistancePriority(.required, for: .vertical)
+        textView.setContentHuggingPriority(.required, for: .vertical)
+        textView.replyHandler = context.coordinator
+        return textView
+    }
+
+    func updateUIView(_ textView: ReplyTextView, context: Context) {
+        context.coordinator.onReply = onReply
+        textView.replyHandler = context.coordinator
+        textView.replyMenuTitle = "Reply to \(replyToName)"
+        if textView.attributedText != attributedText {
+            textView.attributedText = attributedText
+        }
+        textView.invalidateIntrinsicContentSize()
+    }
+
+    class Coordinator {
+        var onReply: (String) -> Void
+
+        init(onReply: @escaping (String) -> Void) {
+            self.onReply = onReply
+        }
+    }
+}
+
+/// Custom UITextView subclass that adds "Reply" to the text selection menu.
+final class ReplyTextView: UITextView {
+    weak var replyHandler: SelectableTextView.Coordinator?
+    var replyMenuTitle: String = "Reply"
+
+    override var canBecomeFirstResponder: Bool { true }
+
+    override var intrinsicContentSize: CGSize {
+        guard bounds.width > 0 else { return super.intrinsicContentSize }
+        let fixedWidth = bounds.width
+        let size = sizeThatFits(CGSize(width: fixedWidth, height: .greatestFiniteMagnitude))
+        return CGSize(width: UIView.noIntrinsicMetric, height: size.height)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        invalidateIntrinsicContentSize()
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(replyAction(_:)) {
+            return selectedRange.length > 0
+        }
+        // Allow standard actions (copy, select all, etc.)
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func buildMenu(with builder: any UIMenuBuilder) {
+        super.buildMenu(with: builder)
+
+        let replyAction = UIAction(title: replyMenuTitle, image: UIImage(systemName: "arrowshape.turn.up.left")) { [weak self] _ in
+            self?.replyAction(nil)
+        }
+
+        let replyMenu = UIMenu(title: "", options: .displayInline, children: [replyAction])
+
+        // Insert at the beginning so it appears prominently
+        if builder.menu(for: .standardEdit) != nil {
+            builder.insertSibling(replyMenu, beforeMenu: .standardEdit)
+        } else {
+            builder.insertChild(replyMenu, atStartOfMenu: .root)
+        }
+    }
+
+    @objc private func replyAction(_ sender: Any?) {
+        guard selectedRange.length > 0,
+              let text = text else { return }
+        let selectedText = (text as NSString).substring(with: selectedRange)
+        let trimmed = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        // Dismiss selection
+        selectedTextRange = nil
+        resignFirstResponder()
+
+        replyHandler?.onReply(trimmed)
+    }
+}

--- a/TalkToMe/Chat/Views/InputAreaView.swift
+++ b/TalkToMe/Chat/Views/InputAreaView.swift
@@ -12,6 +12,7 @@ struct InputAreaView: View {
   let onMicMuteToggle: () -> Void
 
   @Binding var inputText: String
+  @Binding var replyQuoteText: String?
   @Binding var isLoading: Bool
   @Binding var pendingAttachments: [PendingAttachment]
 
@@ -144,6 +145,37 @@ struct InputAreaView: View {
       : (attachmentsTopPadding + xButtonOverhang + thumbSize + gapBelowAttachments)
 
     VStack(alignment: .leading, spacing: 0) {
+      // Reply quote preview
+      if let quoteText = replyQuoteText, !quoteText.isEmpty {
+        HStack(alignment: .top, spacing: 8) {
+          RoundedRectangle(cornerRadius: 1.5)
+            .fill(AppTheme.accent)
+            .frame(width: 3)
+
+          Text(quoteText)
+            .font(.system(size: 14))
+            .foregroundColor(.secondary)
+            .lineLimit(4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+          Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+              replyQuoteText = nil
+            }
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .font(.system(size: 18))
+              .foregroundColor(Color(.tertiaryLabel))
+          }
+          .buttonStyle(.plain)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 2)
+        .padding(.top, 10)
+        .padding(.bottom, 6)
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
+      }
+
       // Reserve space for photo thumbnails (rendered via overlay)
       if !pendingAttachments.isEmpty {
         Color.clear
@@ -291,6 +323,11 @@ struct InputAreaView: View {
           }
           .buttonStyle(.plain)
           .transition(.scale.combined(with: .opacity))
+        }
+      }
+      .onChange(of: replyQuoteText) { _, newValue in
+        if newValue != nil {
+          isInputFocused.wrappedValue = true
         }
       }
       .onChange(of: isVoiceRecording) { _, recording in
@@ -495,6 +532,7 @@ struct GhostVideoContentView: View {
     onSpeakToggle: {},
     onMicMuteToggle: {},
     inputText: .constant(""),
+    replyQuoteText: .constant(nil),
     isLoading: .constant(false),
     pendingAttachments: .constant([]),
     isInputFocused: $isFocused,
@@ -517,6 +555,7 @@ struct GhostVideoContentView: View {
     onSpeakToggle: {},
     onMicMuteToggle: {},
     inputText: .constant(""),
+    replyQuoteText: .constant(nil),
     isLoading: .constant(false),
     pendingAttachments: .constant([]),
     isInputFocused: $isFocused,
@@ -539,6 +578,7 @@ struct GhostVideoContentView: View {
     onSpeakToggle: {},
     onMicMuteToggle: {},
     inputText: .constant(""),
+    replyQuoteText: .constant(nil),
     isLoading: .constant(false),
     pendingAttachments: .constant([]),
     isInputFocused: $isFocused,
@@ -561,6 +601,7 @@ struct GhostVideoContentView: View {
     onSpeakToggle: {},
     onMicMuteToggle: {},
     inputText: .constant(""),
+    replyQuoteText: .constant(nil),
     isLoading: .constant(false),
     pendingAttachments: .constant([]),
     isInputFocused: $isFocused,

--- a/TalkToMe/Chat/Views/MessagesListView.swift
+++ b/TalkToMe/Chat/Views/MessagesListView.swift
@@ -287,6 +287,11 @@ struct MessagesListView: View {
             }
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
+        .onReceive(NotificationCenter.default.publisher(for: .chatContentExpanded)) { _ in
+            guard let sv = underlyingScrollView else { return }
+            sv.layoutIfNeeded()
+            scrollToBottomUIKit(sv, animated: true)
+        }
         .onChange(of: scrollToBottomToken, initial: false) { _, _ in
             guard let sv = underlyingScrollView else { return }
             sv.layoutIfNeeded()
@@ -347,6 +352,18 @@ struct MessagesListView: View {
                     guard let sv = underlyingScrollView else { return }
                     sv.layoutIfNeeded()
                     scrollToTopUIKit(sv, messageY: messageY)
+                }
+            }
+
+            // Re-scroll after layout settles (keyboard + input area height changes)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                guard scrollToTopTargetId == id else { return }
+                guard let sv = underlyingScrollView else { return }
+                sv.layoutIfNeeded()
+                if let messageY = messagePositions[id] {
+                    let targetOffset = messageY - sv.adjustedContentInset.top
+                    enforcedOffsetY = targetOffset
+                    sv.setContentOffset(CGPoint(x: 0, y: targetOffset), animated: true)
                 }
             }
         }

--- a/TalkToMe/ContentView.swift
+++ b/TalkToMe/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
             return authService.currentUserId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         }
         return authService.isAuthenticated
-            && !(onboardingLoaded && onboardingVM.step != .completed)
+            && onboardingLoaded && onboardingVM.step == .completed
     }
 
     var body: some View {
@@ -90,6 +90,7 @@ struct ContentView: View {
         }
         .animation(.easeInOut(duration: 0.3), value: authService.isAuthenticated)
         .animation(.easeInOut(duration: 0.3), value: authService.isCheckingAuth)
+        .animation(.easeInOut(duration: 0.3), value: onboardingLoaded)
     }
 
 }

--- a/TalkToMe/Diary/Views/DiaryView.swift
+++ b/TalkToMe/Diary/Views/DiaryView.swift
@@ -29,12 +29,7 @@ struct DiaryView: View {
         AppTheme.background.ignoresSafeArea()
 
         VStack(spacing: 0) {
-          DiaryHeroCardView(
-            subtitle: viewModel.displayHeroDateString,
-            gradientColors: heroGradientColors,
-            pendingCount: viewModel.todoPendingCount,
-            completedCount: viewModel.todoCompletedCount
-          )
+          DiaryHeroCardView(gradientColors: heroGradientColors)
 
           if !friendCardDismissed {
             addFriendCard
@@ -323,15 +318,31 @@ private extension Color {
 
 private struct DiaryHeroCardView: View {
   @Environment(\.colorScheme) private var colorScheme
-  let subtitle: String
   let gradientColors: [Color]
-  var pendingCount: Int = 0
-  var completedCount: Int = 0
 
-  private var completionRatio: CGFloat {
-    let total = pendingCount + completedCount
-    guard total > 0 else { return 0 }
-    return CGFloat(completedCount) / CGFloat(total)
+  private var displayHeaderDateString: String {
+    let now = Date()
+    let cal = Calendar.current
+    let day = cal.component(.day, from: now)
+    let year = cal.component(.year, from: now)
+
+    let weekdayFormatter = DateFormatter()
+    weekdayFormatter.dateFormat = "EEEE"
+    let weekday = weekdayFormatter.string(from: now)
+
+    let monthFormatter = DateFormatter()
+    monthFormatter.dateFormat = "MMM"
+    let month = monthFormatter.string(from: now)
+
+    let suffix: String
+    switch day {
+    case 1, 21, 31: suffix = "st"
+    case 2, 22: suffix = "nd"
+    case 3, 23: suffix = "rd"
+    default: suffix = "th"
+    }
+
+    return "\(weekday), \(month) \(day)\(suffix) • \(year)"
   }
 
   private var baseGradientColors: [Color] {
@@ -451,93 +462,21 @@ private struct DiaryHeroCardView: View {
         duration: 7.4
       )
 
-      VStack(alignment: .leading, spacing: 10) {
-        let cardShape = RoundedRectangle(cornerRadius: 22, style: .continuous)
+      VStack(alignment: .leading, spacing: 4) {
+        Text("My Diary")
+          .font(.system(size: 40, weight: .bold))
+          .foregroundStyle(.primary)
 
-        VStack(alignment: .leading, spacing: 12) {
-          HStack(alignment: .center, spacing: 14) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("To-Do")
-                .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.primary)
-
-              Text(
-                pendingCount == 0
-                  ? "All tasks are done."
-                  : "\(pendingCount) \(pendingCount == 1 ? "task" : "tasks") pending"
-              )
-              .font(.system(size: 13, weight: .medium))
-              .foregroundStyle(.secondary)
-            }
-
-            Spacer(minLength: 8)
-
-            ZStack {
-              Circle()
-                .stroke(Color.primary.opacity(0.15), lineWidth: 3.5)
-              Circle()
-                .trim(from: 0, to: completionRatio)
-                .stroke(
-                  Color.primary.opacity(0.85),
-                  style: StrokeStyle(lineWidth: 3.5, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-            }
-            .frame(width: 38, height: 38)
-          }
-
-          HStack(spacing: 16) {
-            heroTodoPill(icon: "circle", title: "Pending", value: "\(pendingCount)", tint: gradientColors.first ?? .primary)
-            heroTodoPill(icon: "checkmark.circle.fill", title: "Done", value: "\(completedCount)", tint: .green)
-          }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 16)
-        .clipShape(cardShape)
-        .modifier(HeroGlassModifier(shape: cardShape))
+        Text(displayHeaderDateString)
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(.secondary)
       }
-      .padding(.horizontal, 16)
-      .padding(.top, 120)
-      .padding(.bottom, 14)
+      .padding(.leading, 28)
+      .padding(.top, 140)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
     .frame(height: 340)
     .ignoresSafeArea(edges: .top)
-  }
-
-  private func heroTodoPill(icon: String, title: String, value: String, tint: Color) -> some View {
-    HStack(spacing: 4) {
-      Image(systemName: icon)
-        .font(.system(size: 12, weight: .semibold))
-        .foregroundStyle(tint)
-
-      Text(title)
-        .font(.system(size: 13, weight: .semibold))
-        .foregroundStyle(.secondary)
-
-      Text(value)
-        .font(.system(size: 13, weight: .bold, design: .rounded))
-        .foregroundStyle(.primary)
-        .monospacedDigit()
-    }
-  }
-}
-
-private struct HeroGlassModifier<S: Shape>: ViewModifier {
-  let shape: S
-
-  func body(content: Content) -> some View {
-    if #available(iOS 26.0, *) {
-      content
-        .glassEffect(.regular.interactive(), in: shape)
-    } else {
-      content
-        .background(.ultraThinMaterial)
-        .overlay(
-          shape
-            .stroke(Color.white.opacity(0.15), lineWidth: 0.5)
-        )
-    }
   }
 }
 
@@ -935,13 +874,11 @@ private struct JournalSheetView: View {
         case .overview:
           JournalOverviewTab(
             entries: $entries,
-            todoItems: $todoItems,
             stats: stats,
             accentColor: accentColor,
             selectedDay: $selectedCalendarDay,
             onAddEntryForDate: onAddEntryForDate,
-            onSelectEntry: onSelectEntry,
-            onTodoChange: onTodoChange
+            onSelectEntry: onSelectEntry
           )
         case .list:
           JournalListTab(
@@ -1065,16 +1002,12 @@ private struct JournalTabBar: View {
 
 private struct JournalOverviewTab: View {
   @Binding var entries: [JournalEntry]
-  @Binding var todoItems: [DiaryTodoItem]
   let stats: JournalStats
   let accentColor: Color
   @Binding var selectedDay: Date?
   let onAddEntryForDate: (Date) -> Void
   let onSelectEntry: (JournalEntry) -> Void
-  let onTodoChange: () -> Void
 
-  @State private var newTodoTitle: String = ""
-  @FocusState private var isAddFieldFocused: Bool
   @State private var currentPage: Int?
   @State private var showDaySheet: Bool = false
   @State private var sheetDay: Date?
@@ -1121,12 +1054,6 @@ private struct JournalOverviewTab: View {
 
     ScrollView {
       VStack(alignment: .leading, spacing: 20) {
-        VStack(alignment: .leading, spacing: 10) {
-          overviewAddTaskCard
-          overviewTodosPreview
-        }
-        .padding(.horizontal, 16)
-
         VStack(alignment: .leading, spacing: 8) {
           Text("Trends")
             .font(.system(size: 18, weight: .bold))
@@ -1220,112 +1147,6 @@ private struct JournalOverviewTab: View {
         )
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
-      }
-    }
-  }
-
-  private var overviewAddTaskCard: some View {
-    let trimmed = newTodoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-    let canAdd = !trimmed.isEmpty
-    let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
-
-    return HStack(spacing: 10) {
-      TextField("Add a task...", text: $newTodoTitle)
-        .font(.system(size: 16, weight: .regular))
-        .focused($isAddFieldFocused)
-        .submitLabel(.done)
-        .onSubmit { addTodo() }
-
-      Button {
-        addTodo()
-      } label: {
-        Text("Add")
-          .font(.system(size: 14, weight: .semibold))
-          .foregroundStyle(canAdd ? .primary : .tertiary)
-          .padding(.horizontal, 14)
-          .padding(.vertical, 7)
-          .background(Color(.tertiarySystemFill))
-          .clipShape(Capsule())
-      }
-      .buttonStyle(.plain)
-      .disabled(!canAdd)
-    }
-    .padding(.horizontal, 16)
-    .padding(.vertical, 14)
-    .background { GlassCardBackground(shape: shape) }
-    .clipShape(shape)
-    .overlay(
-      shape
-        .stroke(Color(.separator).opacity(0.22), lineWidth: 0.6)
-    )
-    .contentShape(shape)
-    .onTapGesture {
-      isAddFieldFocused = true
-    }
-  }
-
-  private func addTodo() {
-    let trimmed = newTodoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return }
-    Haptics.impact(.light)
-    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-      todoItems.insert(DiaryTodoItem(title: trimmed), at: 0)
-    }
-    newTodoTitle = ""
-  }
-
-  @ViewBuilder
-  private var overviewTodosPreview: some View {
-    let previewItems = Array(todoItems.prefix(2))
-    if !previewItems.isEmpty {
-      VStack(spacing: 6) {
-        ForEach(previewItems) { item in
-          let shape = RoundedRectangle(cornerRadius: 14, style: .continuous)
-          HStack(spacing: 10) {
-            Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
-              .font(.system(size: 18, weight: .medium))
-              .foregroundStyle(item.isCompleted ? Color.primary.opacity(0.5) : Color.primary.opacity(0.2))
-              .contentTransition(.symbolEffect(.replace))
-
-            Text(item.title)
-              .font(.system(size: 15, weight: .medium))
-              .strikethrough(item.isCompleted)
-              .foregroundStyle(item.isCompleted ? .tertiary : .primary)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .transaction { $0.animation = nil }
-          }
-          .padding(.horizontal, 14)
-          .padding(.vertical, 12)
-          .background { GlassCardBackground(shape: shape) }
-          .clipShape(shape)
-          .overlay(
-            shape
-              .stroke(Color(.separator).opacity(0.18), lineWidth: 0.5)
-          )
-          .contentShape(shape)
-          .onTapGesture {
-            Haptics.impact(.light)
-            if let index = todoItems.firstIndex(where: { $0.id == item.id }) {
-              withAnimation(.spring(response: 0.25, dampingFraction: 0.82)) {
-                todoItems[index].isCompleted.toggle()
-              }
-              onTodoChange()
-            }
-          }
-          .contextMenu {
-            Button(role: .destructive) {
-              if let index = todoItems.firstIndex(where: { $0.id == item.id }) {
-                Haptics.impact(.light)
-                withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-                  todoItems.remove(at: index)
-                }
-                onTodoChange()
-              }
-            } label: {
-              Label("Delete Task", systemImage: "trash")
-            }
-          }
-        }
       }
     }
   }
@@ -1761,6 +1582,8 @@ private let diaryDefaultTodoItems = [
 private struct JournalTodoTab: View {
   @Binding var todoItems: [DiaryTodoItem]
   let onTodoChange: () -> Void
+  @State private var newTodoTitle: String = ""
+  @FocusState private var isAddFieldFocused: Bool
   @State private var showReorderHint: Bool = false
   @State private var activeReorderItemId: UUID?
   @State private var isReorderDragging: Bool = false
@@ -1772,9 +1595,26 @@ private struct JournalTodoTab: View {
   // Swap only after the dragged row has passed roughly one full row+gap distance.
   private let todoReorderSwapDistance: CGFloat = 72
 
+  private var pendingCount: Int {
+    max(0, todoItems.count - completedCount)
+  }
+
+  private var completedCount: Int {
+    todoItems.filter(\.isCompleted).count
+  }
+
+  private var completionRatio: CGFloat {
+    let total = pendingCount + completedCount
+    guard total > 0 else { return 0 }
+    return CGFloat(completedCount) / CGFloat(total)
+  }
+
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 12) {
+        todoSummaryCard
+        addTaskCard
+
         if showReorderHint {
           reorderHintCard
         }
@@ -1821,6 +1661,123 @@ private struct JournalTodoTab: View {
     .background(AppTheme.background)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     .onChange(of: todoItems) { _, _ in onTodoChange() }
+  }
+
+  private var todoSummaryCard: some View {
+    let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+
+    return VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .center, spacing: 14) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("To-Do")
+            .font(.system(size: 24, weight: .bold))
+            .foregroundStyle(.primary)
+
+          Text(
+            pendingCount == 0
+              ? "All tasks are done."
+              : "\(pendingCount) \(pendingCount == 1 ? "task" : "tasks") pending"
+          )
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.secondary)
+        }
+
+        Spacer(minLength: 8)
+
+        ZStack {
+          Circle()
+            .stroke(Color.primary.opacity(0.15), lineWidth: 3.5)
+          Circle()
+            .trim(from: 0, to: completionRatio)
+            .stroke(
+              Color.primary.opacity(0.85),
+              style: StrokeStyle(lineWidth: 3.5, lineCap: .round)
+            )
+            .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 38, height: 38)
+      }
+
+      HStack(spacing: 16) {
+        todoSummaryPill(icon: "circle", title: "Pending", value: "\(pendingCount)", tint: AppTheme.accent)
+        todoSummaryPill(icon: "checkmark.circle.fill", title: "Done", value: "\(completedCount)", tint: .green)
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 16)
+    .background { GlassCardBackground(shape: shape) }
+    .clipShape(shape)
+    .overlay(
+      shape
+        .stroke(Color(.separator).opacity(0.22), lineWidth: 0.6)
+    )
+  }
+
+  private func todoSummaryPill(icon: String, title: String, value: String, tint: Color) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: icon)
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(tint)
+
+      Text(title)
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+
+      Text(value)
+        .font(.system(size: 13, weight: .bold, design: .rounded))
+        .foregroundStyle(.primary)
+        .monospacedDigit()
+    }
+  }
+
+  private var addTaskCard: some View {
+    let trimmed = newTodoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    let canAdd = !trimmed.isEmpty
+    let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+
+    return HStack(spacing: 10) {
+      TextField("Add a task...", text: $newTodoTitle)
+        .font(.system(size: 16, weight: .regular))
+        .focused($isAddFieldFocused)
+        .submitLabel(.done)
+        .onSubmit { addTodo() }
+
+      Button {
+        addTodo()
+      } label: {
+        Text("Add")
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundStyle(canAdd ? .primary : .tertiary)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 7)
+          .background(Color(.tertiarySystemFill))
+          .clipShape(Capsule())
+      }
+      .buttonStyle(.plain)
+      .disabled(!canAdd)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 14)
+    .background { GlassCardBackground(shape: shape) }
+    .clipShape(shape)
+    .overlay(
+      shape
+        .stroke(Color(.separator).opacity(0.22), lineWidth: 0.6)
+    )
+    .contentShape(shape)
+    .onTapGesture {
+      isAddFieldFocused = true
+    }
+  }
+
+  private func addTodo() {
+    let trimmed = newTodoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    Haptics.impact(.light)
+    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+      todoItems.insert(DiaryTodoItem(title: trimmed), at: 0)
+    }
+    newTodoTitle = ""
   }
 
   private var reorderHintCard: some View {

--- a/TalkToMe/Home/Views/HomeView.swift
+++ b/TalkToMe/Home/Views/HomeView.swift
@@ -683,14 +683,18 @@ private struct NotificationItem: Identifiable, Codable {
   let date: Date
   let icon: String
   let sessionId: UUID?
+  let avatarURL: String?
+  var isViewed: Bool
 
-  init(title: String, body: String, date: Date, icon: String, sessionId: UUID? = nil) {
+  init(title: String, body: String, date: Date, icon: String, sessionId: UUID? = nil, avatarURL: String? = nil, isViewed: Bool = false) {
     self.id = UUID()
     self.title = title
     self.body = body
     self.date = date
     self.icon = icon
     self.sessionId = sessionId
+    self.avatarURL = avatarURL
+    self.isViewed = isViewed
   }
 }
 
@@ -711,6 +715,10 @@ private struct NotificationsView: View {
           let items = try? JSONDecoder().decode([NotificationItem].self, from: data) else { return [] }
     return items
   }()
+  @State private var searchText: String = ""
+  @State private var viewedIds: Set<String> = {
+    Set(UserDefaults.standard.stringArray(forKey: "viewed_notification_ids") ?? [])
+  }()
 
   private var groupedNotifications: [(group: NotificationDateGroup, items: [NotificationItem])] {
     let calendar = Calendar.current
@@ -723,7 +731,13 @@ private struct NotificationsView: View {
     var yesterday: [NotificationItem] = []
     var last7: [NotificationItem] = []
 
-    for item in notifications.sorted(by: { $0.date > $1.date }) {
+    let filtered = notifications.filter { item in
+      guard !searchText.isEmpty else { return true }
+      let query = searchText.lowercased()
+      return item.title.lowercased().contains(query) || item.body.lowercased().contains(query)
+    }
+
+    for item in filtered.sorted(by: { $0.date > $1.date }) {
       if item.date >= startOfToday {
         today.append(item)
       } else if item.date >= startOfYesterday {
@@ -808,53 +822,75 @@ private struct NotificationsView: View {
             .padding(.bottom, 0)
 
             Divider()
-              .padding(.horizontal, 0)
+              .padding(.horizontal, -16)
               .padding(.top, 4)
               .padding(.bottom, 4)
           }
 
           // Notification sections
           ForEach(groupedNotifications, id: \.group) { section in
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 0) {
               Text(section.group.rawValue)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.primary)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(Color(.tertiaryLabel))
+                .textCase(.uppercase)
                 .padding(.horizontal, 4)
+                .padding(.bottom, 12)
 
-              ForEach(section.items) { item in
+              ForEach(Array(section.items.enumerated()), id: \.element.id) { index, item in
                 if let sessionId = item.sessionId {
-                  Button { onTap(sessionId) } label: {
+                  Button {
+                    markAsViewed(item)
+                    onTap(sessionId)
+                  } label: {
                     notificationRow(item)
                   }
                   .buttonStyle(.plain)
                 } else {
                   notificationRow(item)
                 }
+
+                Divider()
+                  .padding(.leading, avatarSize + 12)
               }
             }
+            .padding(.bottom, 8)
           }
 
-          if groupedNotifications.isEmpty && apns.isPushEnabled {
-            VStack(spacing: 8) {
-              Image(systemName: "bell.slash")
-                .font(.system(size: 28))
-                .foregroundStyle(Color(.tertiaryLabel))
-              Text("No notifications yet")
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color(.secondaryLabel))
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.top, 40)
-          }
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
         .padding(.bottom, 24)
       }
+
+      if groupedNotifications.isEmpty && apns.isPushEnabled {
+        VStack(spacing: 12) {
+          if !searchText.isEmpty {
+            Image(systemName: "magnifyingglass")
+              .font(.system(size: 56))
+              .foregroundStyle(Color(.tertiaryLabel))
+            Text("No results for \"\(searchText)\"")
+              .font(.system(size: 15, weight: .medium))
+              .foregroundStyle(Color(.secondaryLabel))
+          } else {
+            Image(systemName: "bell.slash")
+              .font(.system(size: 56))
+              .foregroundStyle(Color(.tertiaryLabel))
+            Text("No notifications yet")
+              .font(.system(size: 15, weight: .medium))
+              .foregroundStyle(Color(.secondaryLabel))
+          }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
     }
     .navigationTitle("Notifications")
+    .searchable(text: $searchText, prompt: "Search notifications")
     .onAppear { loadNotifications() }
     .onReceive(NotificationCenter.default.publisher(for: .partnerMessageReceived)) { _ in
+      loadNotifications()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .partnerMessageUnsent)) { _ in
       loadNotifications()
     }
     .onReceive(NotificationCenter.default.publisher(for: .friendAdded)) { _ in
@@ -865,6 +901,10 @@ private struct NotificationsView: View {
   private func loadNotifications() {
     // 1. Build items from delivered OS push notifications.
     let friends = friendsViewModel.friends
+    let allSessions = sessions
+    let unreadSessionIds = Set(allSessions.filter { $0.unreadCount > 0 }.map(\.id))
+    let previousItems = self.notifications
+
     UNUserNotificationCenter.current().getDeliveredNotifications { delivered in
       var items: [NotificationItem] = []
       var coveredSessionIds = Set<UUID>()
@@ -883,29 +923,30 @@ private struct NotificationsView: View {
           ))
         } else if let sidString = userInfo["session_id"] as? String,
                   let sid = UUID(uuidString: sidString) {
+          let avatar = Self.resolveAvatarURL(forSessionId: sid, friends: friends)
           items.append(NotificationItem(
             title: content.title,
             body: content.body,
             date: date,
             icon: "bubble.left.fill",
-            sessionId: sid
+            sessionId: sid,
+            avatarURL: avatar
           ))
           coveredSessionIds.insert(sid)
         }
       }
 
-      // 2. Add unread sessions that have no matching delivered notification
-      //    (e.g. user was in foreground, or notifications were cleared).
-      for session in sessions where !coveredSessionIds.contains(session.id) {
+      // 2. Add unread sessions that have no matching delivered notification.
+      for session in allSessions where session.unreadCount > 0 && !coveredSessionIds.contains(session.id) {
         let date = Self.parseISO8601(session.lastUsedISO8601) ?? Date()
+        let key = "session_friend_user_id_\(session.id.uuidString)"
+        let friendId: UUID? = {
+          guard let raw = UserDefaults.standard.string(forKey: key) else { return nil }
+          return UUID(uuidString: raw)
+        }()
+        let friend = friendId.flatMap { fid in friends.first(where: { $0.id == fid }) }
         let friendName: String = {
-          let key = "session_friend_user_id_\(session.id.uuidString)"
-          if let raw = UserDefaults.standard.string(forKey: key),
-             let friendId = UUID(uuidString: raw),
-             let friend = friends.first(where: { $0.id == friendId }) {
-            let name = friend.fullName.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !name.isEmpty { return name }
-          }
+          if let name = friend?.fullName.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty { return name }
           return UserDefaults.standard.string(forKey: PreferenceKeys.partnerName) ?? "Partner Message"
         }()
         items.append(NotificationItem(
@@ -913,17 +954,58 @@ private struct NotificationsView: View {
           body: session.lastMessageContent ?? "",
           date: date,
           icon: "bubble.left.fill",
-          sessionId: session.id
+          sessionId: session.id,
+          avatarURL: friend?.avatarURL
         ))
+        coveredSessionIds.insert(session.id)
+      }
+
+      // 3. Preserve previously shown items whose sessions are now read — keep as viewed.
+      for prev in previousItems {
+        guard let sid = prev.sessionId, !coveredSessionIds.contains(sid) else { continue }
+        var kept = prev
+        kept.isViewed = true
+        items.append(kept)
       }
 
       DispatchQueue.main.async {
+        // Restore viewed state from persisted IDs + auto-mark read sessions
+        for i in items.indices {
+          if let sid = items[i].sessionId {
+            if self.viewedIds.contains(sid.uuidString) || !unreadSessionIds.contains(sid) {
+              items[i].isViewed = true
+            }
+          }
+        }
         self.notifications = items
         if let data = try? JSONEncoder().encode(items) {
           UserDefaults.standard.set(data, forKey: "cached_notifications")
         }
       }
     }
+  }
+
+  private func markAsViewed(_ item: NotificationItem) {
+    guard let sid = item.sessionId else { return }
+    viewedIds.insert(sid.uuidString)
+    UserDefaults.standard.set(Array(viewedIds), forKey: "viewed_notification_ids")
+    if let idx = notifications.firstIndex(where: { $0.id == item.id }) {
+      notifications[idx].isViewed = true
+      if let data = try? JSONEncoder().encode(notifications) {
+        UserDefaults.standard.set(data, forKey: "cached_notifications")
+      }
+    }
+  }
+
+  private static func resolveAvatarURL(forSessionId sid: UUID, friends: [FriendSummary]) -> String? {
+    let key = "session_friend_user_id_\(sid.uuidString)"
+    guard let raw = UserDefaults.standard.string(forKey: key),
+          let friendId = UUID(uuidString: raw),
+          let friend = friends.first(where: { $0.id == friendId }) else {
+      // Fall back to default partner avatar
+      return UserDefaults.standard.string(forKey: PreferenceKeys.partnerAvatarURL)
+    }
+    return friend.avatarURL
   }
 
   private static func parseISO8601(_ iso: String?) -> Date? {
@@ -936,42 +1018,108 @@ private struct NotificationsView: View {
     return f2.date(from: iso)
   }
 
+  private let avatarSize: CGFloat = 60
+
   @ViewBuilder
   private func notificationRow(_ item: NotificationItem) -> some View {
-    HStack(alignment: .top, spacing: 10) {
-      Image(systemName: item.icon)
-        .font(.system(size: 16))
-        .foregroundColor(.secondary)
-        .frame(width: 24, height: 24)
-        .padding(.top, 10)
+    HStack(alignment: .center, spacing: 12) {
+      notificationAvatar(item)
 
-      VStack(alignment: .leading, spacing: 2) {
-        HStack {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 6) {
           Text(item.title)
-            .font(.system(size: 15, weight: .regular))
-            .foregroundColor(.primary)
-            .lineLimit(2)
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundColor(item.isViewed ? Color(.secondaryLabel) : .primary)
+            .lineLimit(1)
 
           Spacer()
 
-          Text(timeAgoShort(item.date))
-            .font(.system(size: 12, weight: .regular))
-            .foregroundColor(Color(.tertiaryLabel))
+          if item.isViewed {
+            HStack(spacing: 4) {
+              Text("Viewed")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Color(.secondaryLabel))
+
+              Text("·")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(Color(.tertiaryLabel))
+
+              Text(timeAgoShort(item.date))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color(.tertiaryLabel))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(.tertiarySystemFill))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+          } else {
+            HStack(spacing: 4) {
+              Text("Unread")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(AppTheme.brand)
+
+              Text("·")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(Color(.tertiaryLabel))
+
+              Text(timeAgoShort(item.date))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(Color(.tertiaryLabel))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(AppTheme.brand.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+          }
         }
 
         if !item.body.isEmpty {
           Text(item.body)
-            .font(.system(size: 13, weight: .regular))
-            .foregroundColor(.secondary)
+            .font(.system(size: 15))
+            .foregroundColor(item.isViewed ? Color(.tertiaryLabel) : Color(.secondaryLabel))
+            .lineSpacing(4)
             .lineLimit(2)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
       }
-      .padding(.horizontal, 14)
-      .padding(.vertical, 10)
-      .background(AppTheme.surface)
-      .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
-    .padding(.leading, 8)
+    .padding(.vertical, 10)
+  }
+
+  @ViewBuilder
+  private func notificationAvatar(_ item: NotificationItem) -> some View {
+    if let avatarURLString = item.avatarURL, !avatarURLString.isEmpty {
+      AvatarCacheManager.shared.cachedAsyncImage(
+        urlString: avatarURLString,
+        placeholder: { AnyView(avatarPlaceholder(item)) },
+        fallback: { AnyView(avatarPlaceholder(item)) }
+      )
+      .frame(width: avatarSize, height: avatarSize)
+      .clipShape(Circle())
+      .opacity(item.isViewed ? 0.5 : 1)
+    } else {
+      avatarPlaceholder(item)
+        .opacity(item.isViewed ? 0.5 : 1)
+    }
+  }
+
+  private func avatarPlaceholder(_ item: NotificationItem) -> some View {
+    ZStack {
+      Circle()
+        .fill(Color(.tertiarySystemFill))
+        .frame(width: avatarSize, height: avatarSize)
+
+      if item.sessionId != nil {
+        Text(String(item.title.prefix(1)).uppercased())
+          .font(.system(size: 22, weight: .semibold, design: .rounded))
+          .foregroundStyle(.secondary)
+      } else {
+        Image(systemName: item.icon)
+          .font(.system(size: 20))
+          .foregroundStyle(Color(.secondaryLabel))
+      }
+    }
   }
 
   private func timeAgoShort(_ date: Date) -> String {
@@ -1053,20 +1201,11 @@ struct HomeView: View {
 
   private var avatarFallback: some View {
     Circle()
-      .fill(
-        LinearGradient(
-          colors: [
-            Color(red: 0.26, green: 0.58, blue: 1.00),
-            Color(red: 0.63, green: 0.32, blue: 0.98)
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-      )
+      .fill(Color(.tertiarySystemFill))
       .overlay(
         Text(displayName.prefix(1).uppercased())
           .font(.system(size: 12, weight: .semibold, design: .rounded))
-          .foregroundStyle(.white)
+          .foregroundStyle(.secondary)
       )
   }
 
@@ -1113,10 +1252,13 @@ struct HomeView: View {
       }
       .navigationDestination(isPresented: $showNotifications) {
         NotificationsView(
-          sessions: unreadSessions,
+          sessions: sessionsVM.sessions,
           onTap: { sessionId in
-            showNotifications = false
             onOpenChat?(sessionId)
+            // Pop notifications after chat overlay fully covers the screen
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+              showNotifications = false
+            }
           }
         )
       }

--- a/TalkToMe/Services/Authentication/AuthService.swift
+++ b/TalkToMe/Services/Authentication/AuthService.swift
@@ -80,6 +80,8 @@ class AuthService: ObservableObject {
                 self.applyAuthenticatedSession(session)
             }
         } catch {
+            // Silently ignore user-initiated cancellations (e.g. dismissing the OAuth sheet)
+            guard !Self.isAuthCancellation(error) else { return }
             await MainActor.run {
                 self.lastAuthError = self.userFacingAuthMessage(for: error, flow: .signIn)
             }
@@ -117,7 +119,11 @@ class AuthService: ObservableObject {
 
         do {
             print("[AuthService] signUp starting for email: \(normalizedEmail)")
-            let response = try await client.auth.signUp(email: normalizedEmail, password: password)
+            var signUpData: [String: AnyJSON]? = nil
+            if let name = fullName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+                signUpData = ["full_name": .string(name)]
+            }
+            let response = try await client.auth.signUp(email: normalizedEmail, password: password, data: signUpData, redirectTo: redirectURL)
             print("[AuthService] signUp succeeded – user id: \(response.user.id)")
 
             // If confirm-email is enabled, signUp succeeds but there is no session yet.
@@ -170,6 +176,11 @@ class AuthService: ObservableObject {
     }
 
     func signOut() async {
+        // Send offline presence before clearing the session (token still valid).
+        if let token = try? await client.auth.session.accessToken {
+            try? await BackendService.shared.updatePresence(online: false, accessToken: token)
+        }
+
         await MainActor.run {
             UserDefaults.standard.set(true, forKey: PreferenceKeys.didExplicitSignOut)
             self.clearAuthenticatedSession()
@@ -398,6 +409,23 @@ class AuthService: ObservableObject {
         return text.contains("already registered")
             || text.contains("already exists")
             || (text.contains("email") && text.contains("exists"))
+    }
+
+    /// Returns `true` when the error represents the user cancelling an auth flow
+    /// (e.g. dismissing the ASWebAuthenticationSession sheet).
+    private static func isAuthCancellation(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        // ASWebAuthenticationSessionError.canceledLogin (domain …WebAuthenticationSession, code 1)
+        if nsError.domain == ASWebAuthenticationSessionError.errorDomain,
+           nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+            return true
+        }
+        // ASAuthorizationError.canceled (domain com.apple.AuthenticationServices.AuthorizationError, code 1001)
+        if nsError.domain == ASAuthorizationError.errorDomain,
+           nsError.code == ASAuthorizationError.canceled.rawValue {
+            return true
+        }
+        return false
     }
 
     private func userFacingAuthMessage(for error: Error, flow: AuthFlow) -> String {

--- a/TalkToMe/Services/Backend/BackendServiceNotifications.swift
+++ b/TalkToMe/Services/Backend/BackendServiceNotifications.swift
@@ -8,8 +8,9 @@ extension BackendService {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        struct Body: Codable { let token: String; let platform: String; let bundle_id: String }
-        request.httpBody = try jsonEncoder.encode(Body(token: token, platform: platform, bundle_id: bundleId))
+        struct Body: Codable { let token: String; let platform: String; let bundle_id: String; let timezone: String }
+        let tz = TimeZone.current.identifier
+        request.httpBody = try jsonEncoder.encode(Body(token: token, platform: platform, bundle_id: bundleId, timezone: tz))
         let (data, response) = try await urlSession.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             let serverMessage = decodeSimpleDetail(from: data) ?? String(data: data, encoding: .utf8) ?? "Unknown server error"

--- a/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
+++ b/TalkToMe/Services/Backend/DeepgramStreamingSTTService.swift
@@ -109,6 +109,7 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func disconnect() {
+        print("[VoiceAgent][STT] disconnect() called — isConnected=\(isConnected) isRecording=\(isRecording)")
         SharedAudioEngine.shared.removeInputTap()
         stopKeepAlive()
         isConnected = false
@@ -231,6 +232,7 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
             Task { @MainActor in
                 switch result {
                 case .failure(let err):
+                    print("[VoiceAgent][STT] receiveLoop failure: \(err) isRecording=\(self.isRecording)")
                     let existing = (self.lastError ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                     if existing.isEmpty {
                         self.lastError = err.localizedDescription
@@ -241,6 +243,8 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
                     self.handle(message: msg)
                     if self.isConnected {
                         self.receiveLoop()
+                    } else {
+                        print("[VoiceAgent][STT] receiveLoop — no longer connected after handling message, stopping receive loop")
                     }
                 }
             }

--- a/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
+++ b/TalkToMe/Services/Backend/ElevenLabsStreamingTTSService.swift
@@ -46,6 +46,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
 
     @MainActor
     func preconnect(voiceId: String, voiceName: String? = nil, config: Config = .init()) async {
+        print("[VoiceAgent][TTS] preconnect called — voiceId=\(voiceId) currentConnected=\(isConnected) connectedVoiceId=\(connectedVoiceId ?? "nil")")
         if isConnected {
             if voiceId == connectedVoiceId { return }
             stopKeepAlive()
@@ -58,14 +59,18 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         self.voiceId = voiceId
         self.voiceName = voiceName
 
-        guard let token = await AuthService.shared.getAccessToken() else { return }
+        guard let token = await AuthService.shared.getAccessToken() else {
+            print("[VoiceAgent][TTS] preconnect failed — no access token")
+            return
+        }
         do {
             try await openWebSocket(token: token)
             self.isConnected = true
             self.receiveLoop()
             self.startKeepAlive()
+            print("[VoiceAgent][TTS] preconnect succeeded")
         } catch {
-            // Silently fail — we'll connect normally when start() is called
+            print("[VoiceAgent][TTS] preconnect failed: \(error)")
         }
     }
 
@@ -144,17 +149,20 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
 
     @MainActor
     func finish() {
+        print("[VoiceAgent][TTS] finish() — isConnected=\(isConnected) pendingText=\(pendingText.count)chars isSpeaking=\(isSpeaking)")
         finishSent = true
         if isConnected {
             flushPendingTextImmediately()
             sendEvent(["type": "end"])
         } else {
+            print("[VoiceAgent][TTS] finish() — not connected, setting pendingFinish=true")
             pendingFinish = true
         }
     }
 
     @MainActor
     func cancel() {
+        print("[VoiceAgent][TTS] cancel() — isConnected=\(isConnected) isSpeaking=\(isSpeaking)")
         flushWorkItem?.cancel()
         flushWorkItem = nil
         pendingText = ""
@@ -229,6 +237,7 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
             Task { @MainActor in
                 switch result {
                 case .failure(let err):
+                    print("[VoiceAgent][TTS] receiveLoop failure: \(err) finishSent=\(self.finishSent)")
                     if self.finishSent {
                         self.isConnected = false
                         self.wsTask = nil
@@ -268,10 +277,12 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         if !audioB64.isEmpty {
             enqueuePCMChunk(base64PCM: audioB64, isLast: isFinal)
         } else if isFinal {
+            print("[VoiceAgent][TTS] received isFinal with no audio — scheduling end sentinel")
             scheduleEndSentinel()
         }
 
         if isFinal {
+            print("[VoiceAgent][TTS] isFinal received — closing WS and preconnecting. audioB64Len=\(audioB64.count) isSpeaking=\(isSpeaking)")
             finishSent = true
             stopKeepAlive()
             wsTask?.cancel(with: .normalClosure, reason: nil)
@@ -372,9 +383,11 @@ final class ElevenLabsStreamingTTSService: ObservableObject, @unchecked Sendable
         silence.frameLength = 1
         silence.int16ChannelData!.pointee.initialize(to: 0)
 
+        print("[VoiceAgent][TTS] scheduling end sentinel buffer")
         SharedAudioEngine.shared.playerNode.scheduleBuffer(silence) { [weak self] in
             guard let self else { return }
             self.audioQueue.async {
+                print("[VoiceAgent][TTS] end sentinel completed — stopping playback, setting isSpeaking=false")
                 self.startedPlayback = false
                 SharedAudioEngine.shared.playerNode.stop()
                 SharedAudioEngine.shared.removeSpeakerLevelTap()

--- a/TalkToMe/Services/PushNotifications/APNSService.swift
+++ b/TalkToMe/Services/PushNotifications/APNSService.swift
@@ -120,6 +120,16 @@ extension APNSService: UNUserNotificationCenterDelegate {
     @MainActor
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
+
+        // Silent unsend push — retract notification and refresh, no banner
+        if let type = userInfo["type"] as? String, type == "partner_unsend" {
+            if let sessionIdString = userInfo["session_id"] as? String,
+               let sessionId = UUID(uuidString: sessionIdString) {
+                handleUnsendPush(sessionId: sessionId)
+            }
+            return []
+        }
+
         if let sessionIdString = userInfo["session_id"] as? String,
            let sessionId = UUID(uuidString: sessionIdString) {
             if AuthService.shared.isAuthenticated {
@@ -169,6 +179,40 @@ extension APNSService: UNUserNotificationCenterDelegate {
         if let type = userInfo["type"] as? String, type == "friend_added" {
             if AuthService.shared.isAuthenticated {
                 NotificationCenter.default.post(name: .friendAdded, object: nil)
+            }
+        }
+    }
+
+    /// Called from AppDelegate for background silent pushes.
+    @MainActor
+    func handleBackgroundPush(userInfo: [AnyHashable: Any]) {
+        if let type = userInfo["type"] as? String, type == "partner_unsend",
+           let sessionIdString = userInfo["session_id"] as? String,
+           let sessionId = UUID(uuidString: sessionIdString) {
+            handleUnsendPush(sessionId: sessionId)
+        }
+    }
+
+    private func handleUnsendPush(sessionId: UUID) {
+        // Remove any delivered notifications for this session
+        removeDeliveredNotifications(forSessionId: sessionId)
+        // Notify the app to refresh
+        if AuthService.shared.isAuthenticated {
+            NotificationCenter.default.post(name: .partnerMessageUnsent, object: nil, userInfo: ["sessionId": sessionId])
+        }
+    }
+
+    private func removeDeliveredNotifications(forSessionId sessionId: UUID) {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let idsToRemove = notifications
+                .filter { notification in
+                    guard let nSessionId = notification.request.content.userInfo["session_id"] as? String else { return false }
+                    return nSessionId == sessionId.uuidString
+                }
+                .map { $0.request.identifier }
+            if !idsToRemove.isEmpty {
+                center.removeDeliveredNotifications(withIdentifiers: idsToRemove)
             }
         }
     }

--- a/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
+++ b/TalkToMe/Settings/ViewModels/SettingsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Combine
 
 
 @MainActor
@@ -10,15 +11,13 @@ class SettingsViewModel: ObservableObject {
     @Published var isUploadingAvatar: Bool = false
     @Published var avatarURL: String? = nil
     @Published var showPersonalizationEdit: Bool = false
-    @Published var shouldNavigateToContacts: Bool = false
-    @Published var shouldNavigateToAppearance: Bool = false
     @Published var shouldHighlightCustomization: Bool = false
     @Published var shouldNavigateToBuddyChooser: Bool = false
-    @Published var shouldNavigateToEditProfile: Bool = false
     @Published var showDeleteAccountConfirmation: Bool = false
     @Published var isDeletingAccount: Bool = false
 
     private let avatarCacheManager = AvatarCacheManager.shared
+    private var pushEnabledCancellable: AnyCancellable?
 
     @Published var fullName: String = ""
     @Published var bio: String = ""
@@ -34,6 +33,20 @@ class SettingsViewModel: ObservableObject {
             self.isProfileLoaded = true
         }
         setupSettingsSections()
+
+        // Keep notifications toggle in sync when changed from outside (e.g. NotificationsView)
+        pushEnabledCancellable = APNSService.shared.$isPushEnabled
+            .receive(on: RunLoop.main)
+            .sink { [weak self] enabled in
+                self?.syncNotificationsToggle(enabled)
+            }
+    }
+
+    private func syncNotificationsToggle(_ enabled: Bool) {
+        guard let sectionIdx = settingsSections.firstIndex(where: { $0.id == "toggles" }),
+              let settingIdx = settingsSections[sectionIdx].settings.firstIndex(where: { $0.title == "Notifications" })
+        else { return }
+        settingsSections[sectionIdx].settings[settingIdx].type = .toggle(enabled)
     }
 
     private func loadSettings() {
@@ -164,21 +177,25 @@ class SettingsViewModel: ObservableObject {
     }
 
     func deleteAccount() {
-        // Grab token before signing out
-        let token = Task { await AuthService.shared.getAccessToken() }
+        isDeletingAccount = true
+        Task {
+            // 1. Grab the token BEFORE signing out so it's still valid
+            let token = await AuthService.shared.getAccessToken()
 
-        // Sign out and purge local data immediately — don't block the UI
-        Self.purgeAllLocalData()
-        Task { await AuthService.shared.signOut() }
+            // 2. Purge local data and sign out
+            await MainActor.run { Self.purgeAllLocalData() }
+            await AuthService.shared.signOut()
 
-        // Fire-and-forget backend deletion
-        Task.detached {
-            guard let token = await token.value else { return }
-            do {
-                try await BackendService.shared.deleteAccount(accessToken: token)
-            } catch {
-                print("Failed to delete account on server: \(error)")
+            // 3. Delete on the backend with the captured token
+            if let token {
+                do {
+                    try await BackendService.shared.deleteAccount(accessToken: token)
+                } catch {
+                    print("Failed to delete account on server: \(error)")
+                }
             }
+
+            await MainActor.run { isDeletingAccount = false }
         }
     }
 

--- a/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
+++ b/TalkToMe/Settings/Views/Components/FriendsAndContactsSectionView.swift
@@ -269,7 +269,7 @@ struct FriendsAndContactsSectionView: View {
                 ForEach(friendsViewModel.friends) { friend in
                     HStack(spacing: 14) {
                         ZStack(alignment: .bottomTrailing) {
-                            SidebarAvatarView(avatarURL: friend.avatarURL)
+                            SidebarAvatarView(avatarURL: friend.avatarURL, name: friend.fullName)
                                 .frame(width: 44, height: 44)
                                 .clipShape(Circle())
 

--- a/TalkToMe/Settings/Views/Components/OnboardingFlowView.swift
+++ b/TalkToMe/Settings/Views/Components/OnboardingFlowView.swift
@@ -214,6 +214,7 @@ struct OnboardingFlowView: View {
         Capsule(style: .continuous)
           .stroke(Color.primary.opacity(0.08), lineWidth: 1)
       )
+      .contentShape(Capsule())
     }
     .buttonStyle(.plain)
   }
@@ -584,6 +585,7 @@ struct OnboardingFlowView: View {
               .stroke(isSelected ? Color.white.opacity(0.22) : Color.primary.opacity(0.08), lineWidth: 1)
           )
       )
+      .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
     .buttonStyle(.plain)
   }
@@ -621,6 +623,7 @@ struct OnboardingFlowView: View {
               .stroke(isSelected ? Color.white.opacity(0.2) : Color.primary.opacity(0.08), lineWidth: 1)
           )
       )
+      .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
     .buttonStyle(.plain)
   }
@@ -655,6 +658,7 @@ struct OnboardingFlowView: View {
             )
         )
         .foregroundColor(.white)
+        .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
       }
       .buttonStyle(.plain)
       .disabled(isSaving)

--- a/TalkToMe/Settings/Views/SettingsView.swift
+++ b/TalkToMe/Settings/Views/SettingsView.swift
@@ -49,9 +49,8 @@ struct SettingsView: View {
     if let user = AuthService.shared.currentUser {
       if let n = user.userMetadata["full_name"]?.stringValue, !n.isEmpty { return n }
       if let n = user.userMetadata["name"]?.stringValue, !n.isEmpty { return n }
-      if let email = user.email { return email.components(separatedBy: "@").first ?? "User" }
     }
-    return "User"
+    return "You"
   }
 
   private var avatarView: some View {
@@ -77,7 +76,7 @@ struct SettingsView: View {
       } label: {
         VStack(spacing: 6) {
           avatarView
-            .frame(height: 120)
+            .frame(width: 120, height: 120)
           Text(preferredName.components(separatedBy: " ").first ?? preferredName)
             .font(.system(size: 18, weight: .semibold))
             .foregroundColor(.primary)
@@ -288,14 +287,8 @@ struct SettingsView: View {
       if let toastMessage {
         ToastOverlayView(message: toastMessage, onDismiss: dismissToast)
           .padding(.top, 8)
+          .transition(.move(edge: .top).combined(with: .opacity))
       }
-    }
-    .animation(.spring(response: 0.3, dampingFraction: 0.8), value: toastMessage)
-    .navigationDestination(isPresented: $viewModel.shouldNavigateToContacts) {
-      FriendsAndContactsSectionView()
-    }
-    .navigationDestination(isPresented: $viewModel.shouldNavigateToAppearance) {
-      AppearanceSettingsView()
     }
     .sheet(isPresented: $viewModel.shouldNavigateToBuddyChooser) {
       BuddyChooserView()
@@ -304,6 +297,8 @@ struct SettingsView: View {
       ToolbarItem(placement: .topBarTrailing) {
         Menu {
           if let code = friendsVM.myCode {
+            Text("You add-a-friend code. Send it to your friend!")
+              .font(.system(size: 10))
             Button {
               UIPasteboard.general.string = code
               Haptics.impact(.light)
@@ -319,8 +314,8 @@ struct SettingsView: View {
             }
           }
         } label: {
-          Image(systemName: "textformat.123")
-            .font(.system(size: 16))
+          Image(systemName: "number")
+            .font(.system(size: 16, weight: .semibold))
             .foregroundStyle(.primary)
         }
       }

--- a/TalkToMe/Shared/AppTheme.swift
+++ b/TalkToMe/Shared/AppTheme.swift
@@ -55,6 +55,7 @@ extension Color {
   static let paletteSurfaceDark = Color(hex: "#1C2533")!  // Slightly lighter navy for cards
   static let paletteSurfaceLight = Color(hex: "#FFFFFF")!
   static let palettePartner = Color(hex: "#F6E6EC")!
+  static let palettePartnerBubbleLightGray = Color(hex: "#E7EBEF")!
 
   // Legacy Static Aliases (Deprecated but kept for compatibility)
   static let talkToMeBrand = paletteSkyBlue
@@ -73,6 +74,7 @@ extension Color {
         trait.userInterfaceStyle == .dark ? UIColor(hex: "#1C2533")! : UIColor(hex: "#EAF6FF")!
       })
   }
+  static let talkToMePartnerBubbleLightGray = palettePartnerBubbleLightGray
   static let talkToMeBubbleUser = talkToMeBrand
 }
 

--- a/TalkToMe/Shared/Notifications.swift
+++ b/TalkToMe/Shared/Notifications.swift
@@ -18,8 +18,10 @@ extension Notification.Name {
     static let sendPartnerMessageFromBubble = Notification.Name("chat.partner.send.from.bubble")
     static let unsendPartnerMessageFromBubble = Notification.Name("chat.partner.unsend.from.bubble")
     static let unsendPartnerMessageResult = Notification.Name("chat.partner.unsend.result")
+    static let partnerMessageUnsent = Notification.Name("partner.message.unsent")
     static let openAddFriendSheet = Notification.Name("chat.open.add.friend.sheet")
     static let openChatSession = Notification.Name("chat.open.session")
     static let openMediaPanel = Notification.Name("chat.open.media.panel")
+    static let chatContentExpanded = Notification.Name("chat.content.expanded")
     static let openNewDiaryEntry = Notification.Name("diary.open.new.entry")
 }

--- a/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
+++ b/TalkToMe/Sidebar/ViewModels/ChatSessionsViewModel.swift
@@ -163,6 +163,13 @@ final class ChatSessionsViewModel: ObservableObject {
             }
         )
         notificationTokens.append(
+            nc.addObserver(forName: .partnerMessageUnsent, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor in
+                    await self?.refreshSessions()
+                }
+            }
+        )
+        notificationTokens.append(
             nc.addObserver(forName: .partnerMessageOpen, object: nil, queue: .main) { [weak self] note in
                 MainActor.assumeIsolated {
                     guard let sid = note.userInfo?["sessionId"] as? UUID else { return }

--- a/TalkToMe/Sidebar/Views/Components/SidebarAvatarView.swift
+++ b/TalkToMe/Sidebar/Views/Components/SidebarAvatarView.swift
@@ -2,12 +2,31 @@ import SwiftUI
 
 struct SidebarAvatarView: View {
     let avatarURL: String?
+    var name: String? = nil
 
     @State private var image: UIImage?
     @State private var isLoading = false
     @State private var refreshKey = UUID()
 
     private let avatarCacheManager = AvatarCacheManager.shared
+
+    private var placeholderView: some View {
+        Circle()
+            .fill(Color(.tertiarySystemFill))
+            .overlay(
+                Group {
+                    if let name, let first = name.first {
+                        Text(String(first).uppercased())
+                            .font(.system(size: 16, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            )
+    }
 
     var body: some View {
         Group {
@@ -16,39 +35,9 @@ struct SidebarAvatarView: View {
                     .resizable()
                     .scaledToFill()
             } else if isLoading {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(red: 0.26, green: 0.58, blue: 1.00),
-                                Color(red: 0.63, green: 0.32, blue: 0.98)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .overlay(
-                        Image(systemName: "person.fill")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.white)
-                    )
+                placeholderView
             } else {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(red: 0.26, green: 0.58, blue: 1.00),
-                                Color(red: 0.63, green: 0.32, blue: 0.98)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .overlay(
-                        Image(systemName: "person.fill")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(.white)
-                    )
+                placeholderView
             }
         }
         .id(refreshKey)

--- a/TalkToMe/Sidebar/Views/SidebarView.swift
+++ b/TalkToMe/Sidebar/Views/SidebarView.swift
@@ -222,17 +222,12 @@ struct SidebarView: View {
 
   @ViewBuilder
   private var ghostToolbarImage: some View {
-    if let videoName = ElevenLabsVoiceSuggestionsView.ghostVideoName(for: effectiveVoiceName),
-       Bundle.main.url(forResource: videoName, withExtension: "mp4") != nil {
-      TransparentVideoPlayerView(
-        videoName: videoName,
-        videoExtension: "mp4",
-        startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[videoName] ?? 0
-      )
-    } else if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: effectiveVoiceName) {
+    if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: effectiveVoiceName) {
       Image(uiImage: uiImage)
         .resizable()
-        .scaledToFit()
+        .scaledToFill()
+        .frame(width: 30, height: 30)
+        .clipShape(Circle())
     } else {
       Image(systemName: "waveform")
         .font(.system(size: 18, weight: .semibold))
@@ -796,7 +791,7 @@ struct FriendsSheetView: View {
   private func friendRow(_ friend: FriendSummary) -> some View {
     HStack(spacing: 14) {
       ZStack(alignment: .bottomTrailing) {
-        SidebarAvatarView(avatarURL: friend.avatarURL)
+        SidebarAvatarView(avatarURL: friend.avatarURL, name: friend.fullName)
           .frame(width: 44, height: 44)
           .clipShape(Circle())
 


### PR DESCRIPTION
This PR includes all current workspace changes across backend and iOS app. On backend, it adds device-token schema migrations (timezone + uniqueness), APNS service/router/crud updates, daily check-in scheduling, and related chat/friends/partner/profile endpoint adjustments. On iOS, it refines diary header/date behavior, updates home/settings/sidebar polish, and wires notification/auth/theme improvements. It also adds chat UX features and fixes across streaming/voice/message rendering, including new quoted-reply and selectable-text components plus partner draft/message interaction updates.