### PR TITLE
Fix chat streaming, empty states, and session handling

### DIFF
--- a/BoBo/Chat/Controllers/ChatStreamingController.swift
+++ b/BoBo/Chat/Controllers/ChatStreamingController.swift
@@ -40,6 +40,9 @@ final class ChatStreamingController {
     private var currentStreamingSessionId: UUID?
     private var pendingRegenerationCount: Int = 0
     private var ghostNameBySession: [UUID: String] = [:]
+    /// Session IDs created locally by `sendMessage()` during this app lifecycle.
+    /// Used to distinguish orphan local sessions from server-known sessions after restart.
+    private var locallyCreatedSessionIds: Set<UUID> = []
 
     private weak var delegate: ChatStreamingDelegate?
     private var onCacheUpdate: (() -> Void)?
@@ -152,6 +155,7 @@ final class ChatStreamingController {
         if delegate.sessionId == nil {
             let localId = UUID()
             createdLocalSessionId = localId
+            locallyCreatedSessionIds.insert(localId)
             delegate.sessionId = localId
             delegate.setChatMessagesVMSessionId(localId)
             let currentTime = ISO8601DateFormatter().string(from: Date())
@@ -378,7 +382,13 @@ final class ChatStreamingController {
 
             let localSessionIdForSend = sid
             let createdLocalSessionIdForSend = createdLocalSessionId
-            let requestSessionIdForStream: UUID? = (createdLocalSessionIdForSend != nil) ? nil : localSessionIdForSend
+            // Send nil session ID if this is a locally-created session the server
+            // has never acknowledged.  Only sessions created during this app lifecycle
+            // (tracked in locallyCreatedSessionIds) can be orphans.  Sessions loaded
+            // from DB after app restart are already server-known and safe to send as-is.
+            let isUnacknowledgedLocalSession = self.locallyCreatedSessionIds.contains(localSessionIdForSend)
+                && self.responseIdBySession[localSessionIdForSend] == nil
+            let requestSessionIdForStream: UUID? = (createdLocalSessionIdForSend != nil || isUnacknowledgedLocalSession) ? nil : localSessionIdForSend
 
             await MainActor.run {
                 self.isStreaming = true
@@ -485,14 +495,16 @@ final class ChatStreamingController {
                 guard let self = self, let delegate = delegate else { return }
                 switch event {
                 case .responseId(let rid):
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         let targetSid = streamSessionId ?? delegate.sessionId
                         if let sid = targetSid {
                             self.responseIdBySession[sid] = rid
                         }
                     }
                 case .toolStart:
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         let targetSid = streamSessionId ?? delegate.sessionId
                         guard let sid = targetSid else { return }
                         if sid == delegate.sessionId {
@@ -545,7 +557,8 @@ final class ChatStreamingController {
                 case .toolArgs:
                     break
                 case .toolDone:
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         let targetSid = streamSessionId ?? delegate.sessionId
                         guard let sid = targetSid else { return }
                         if sid == delegate.sessionId {
@@ -597,7 +610,8 @@ final class ChatStreamingController {
                     }
                 case .thinking(let text):
                     accumulatedThinking += text
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         if !self.receivedAnyAssistantOutput {
                             self.typingDelayTask?.cancel()
                             delegate.isAssistantTyping = true
@@ -605,15 +619,28 @@ final class ChatStreamingController {
                         delegate.thinkingText += text
                     }
                 case .thinkingDone:
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         delegate.thinkingTextDone = true
                     }
                 case .session(let sid):
                     streamSessionId = sid
-                    Task { @MainActor in
-                        let isRekey = createdLocalSessionIdForSend != nil
+                    Task { @MainActor [streamToken] in
+                        // Discard stale .session events from a cancelled stream.
+                        // After stopGeneration() nils currentStreamToken, this
+                        // event must not rekey sessions or change delegate state.
+                        guard self.currentStreamToken == streamToken else { return }
+
+                        let isNewlyCreatedRekey = createdLocalSessionIdForSend != nil
                             && delegate.sessionId == createdLocalSessionIdForSend
                             && sid != createdLocalSessionIdForSend
+                        // Also rekey if the local session existed but the server
+                        // didn't know about it (we sent nil session ID).
+                        let isOrphanRekey = createdLocalSessionIdForSend == nil
+                            && isUnacknowledgedLocalSession
+                            && delegate.sessionId == localSessionIdForSend
+                            && sid != localSessionIdForSend
+                        let isRekey = isNewlyCreatedRekey || isOrphanRekey
 
                         // Update session tracking state synchronously BEFORE any
                         // async work so that token/done handlers arriving during
@@ -631,7 +658,9 @@ final class ChatStreamingController {
                         }
                         self.currentStreamingSessionId = sid
 
-                        if isRekey, let local = createdLocalSessionIdForSend {
+                        let localIdToRekey = createdLocalSessionIdForSend ?? (isOrphanRekey ? localSessionIdForSend : nil)
+                        if isRekey, let local = localIdToRekey {
+                            self.locallyCreatedSessionIds.remove(local)
                             await ChatStore.shared.rekeySession(oldId: local, newId: sid)
                             if let ghostName = self.ghostNameBySession[local] {
                                 self.ghostNameBySession[sid] = ghostName
@@ -649,7 +678,8 @@ final class ChatStreamingController {
                         }
                     }
                 case .token(let token):
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         let targetSid = streamSessionId ?? delegate.sessionId
                         guard let sid = targetSid else { return }
                         if !self.receivedAnyAssistantOutput {
@@ -786,7 +816,8 @@ final class ChatStreamingController {
                     print("[VoiceAgent] SSE .done received — voiceAgent=\(voiceAgentToSend ?? "nil") accumulatedLen=\(accumulated.count) isVoiceMode=\(isVoiceModeMessage) currentActiveVoice=\(self.activeVoiceAgentName ?? "nil")")
                     let targetSid = streamSessionId ?? delegate.sessionId
                     if let sid = targetSid, sid != delegate.sessionId {
-                        Task { @MainActor in
+                        Task { @MainActor [streamToken] in
+                            guard self.currentStreamToken == streamToken else { return }
                             if let arr = delegate.getCachedMessages(for: sid) {
                                 delegate.setCachedMessages(arr, for: sid)
                             }
@@ -806,7 +837,8 @@ final class ChatStreamingController {
                         }
                     } else {
                         let capturedRegenCount = self.pendingRegenerationCount
-                        Task { @MainActor in
+                        Task { @MainActor [streamToken] in
+                            guard self.currentStreamToken == streamToken else { return }
                             // Apply regeneration count to the completed message
                             if self.pendingRegenerationCount > 0,
                                let msgId = self.currentAssistantMessageId,
@@ -923,12 +955,14 @@ final class ChatStreamingController {
                 case .error(let message):
                     print("[VoiceAgent] SSE .error received: \(message) — voiceAgent=\(voiceAgentToSend ?? "nil")")
                     if message.contains("previous_response_not_found") || (message.contains("previous_response_id") && message.contains("not found")) {
-                        Task { @MainActor in
+                        Task { @MainActor [streamToken] in
+                            guard self.currentStreamToken == streamToken else { return }
                             let sid = streamSessionId ?? localSessionIdForSend
                             self.responseIdBySession.removeValue(forKey: sid)
                         }
                     }
-                    Task { @MainActor in
+                    Task { @MainActor [streamToken] in
+                        guard self.currentStreamToken == streamToken else { return }
                         let targetSid = streamSessionId ?? delegate.sessionId
                         if let sid = targetSid, sid != delegate.sessionId {
                             var newMessages = delegate.getCachedMessages(for: sid) ?? []
@@ -1046,7 +1080,57 @@ final class ChatStreamingController {
         delegate?.thinkingText = ""
         delegate?.thinkingTextDone = false
         isStreaming = false
+
+        // Mark the assistant message as stopped so the UI can show
+        // action buttons (e.g. regenerate) even if no tokens arrived.
+        let stoppedMsgId = currentAssistantMessageId
+        if let msgId = stoppedMsgId,
+           let delegate,
+           let idx = delegate.messages.firstIndex(where: { $0.id == msgId }) {
+            delegate.messages[idx].wasStopped = true
+
+            // Persist to GRDB so the stopped message survives reconciliation
+            // and app restarts.
+            let msg = delegate.messages[idx]
+            let content = msg.segments.compactMap { seg -> String? in
+                if case .text(let t) = seg { return t }
+                return nil
+            }.joined()
+            let sid = currentStreamingSessionId ?? delegate.sessionId
+            let isVoice = msg.isFromVoiceMode
+            let ghost = msg.ghostName
+            if let sid {
+                let userId: UUID? = {
+                    if let uid = AuthService.shared.currentUser?.id { return uid }
+                    if let raw = UserDefaults.standard.string(forKey: PreferenceKeys.currentUserId),
+                       let uid = UUID(uuidString: raw) { return uid }
+                    return nil
+                }()
+                if let userId {
+                    Task {
+                        await ChatStore.shared.persistStoppedMessage(
+                            messageId: msgId,
+                            sessionId: sid,
+                            userId: userId,
+                            content: content,
+                            isVoiceMode: isVoice,
+                            ghostName: ghost
+                        )
+                    }
+                }
+            }
+        }
+
+        // Update cache so the generated text survives and action buttons
+        // (copy, regenerate, etc.) appear immediately.
+        if let sid = currentStreamingSessionId ?? delegate?.sessionId {
+            delegate?.setCachedMessages(delegate?.messages ?? [], for: sid)
+        }
+
         currentAssistantMessageId = nil
+        currentStreamingSessionId = nil
+        delegate?.streamingDidFinish()
+        onCacheUpdate?()
     }
 
     func regenerateResponse(forAssistantMessageId assistantMessageId: UUID) {

--- a/BoBo/Chat/Controllers/ChatVoiceModeController.swift
+++ b/BoBo/Chat/Controllers/ChatVoiceModeController.swift
@@ -353,6 +353,8 @@ final class ChatVoiceModeController: ObservableObject {
     }
 
     func startSpeakMode() {
+        guard !isSpeakModeActive else { return }
+        isSpeakModeActive = true
         speakSessionSeq += 1
         turnSeq = 0
         speakSessionStartTime = Date()
@@ -385,7 +387,6 @@ final class ChatVoiceModeController: ObservableObject {
         speakModeVoiceId = storedVoiceId
         streamingController?.activeVoiceAgentName = name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : name
 
-        isSpeakModeActive = true
         isSpeakComposerLocked = false
         pendingSpeakAutoSendTask?.cancel()
         pendingSpeakAutoSendTask = nil

--- a/BoBo/Chat/Models/ChatMessage.swift
+++ b/BoBo/Chat/Models/ChatMessage.swift
@@ -23,6 +23,7 @@ struct ChatMessage: Identifiable {
     var regenerationCount: Int
     var ghostName: String?
     var thinkingSummary: String?
+    var wasStopped: Bool = false
 
     static func text(_ text: String, isFromUser: Bool, timestamp: Date = Date(), isFromVoiceMode: Bool = false) -> ChatMessage {
         return ChatMessage(

--- a/BoBo/Chat/Views/ChatScreenView.swift
+++ b/BoBo/Chat/Views/ChatScreenView.swift
@@ -4,7 +4,7 @@ struct ChatScreenView: View {
 
   @ObservedObject var chatViewModel: ChatViewModel
 
-  @AppStorage(PreferenceKeys.dictationEnabled) private var dictationEnabled: Bool = false
+  @AppStorage(PreferenceKeys.dictationEnabled) private var dictationEnabled: Bool = true
 
   let onSend: () -> Void
   let isInputFocused: FocusState<Bool>.Binding

--- a/BoBo/Chat/Views/ChatView.swift
+++ b/BoBo/Chat/Views/ChatView.swift
@@ -97,7 +97,6 @@ struct ChatView: View {
                         sessionId: activeSessionIdForActions,
                         currentTitle: activeSessionTitleForActions,
                         onRenameRequest: { sessionActions.requestRename(currentTitle: activeSessionTitleForActions) },
-                        onArchiveRequest: { sessionActions.requestArchive() },
                         onDeleteRequest: { sessionActions.requestDelete() },
                         onReportRequest: { sessionActions.requestReport() }
                     )

--- a/BoBo/Chat/Views/Components/ChatSessionActionsModifier.swift
+++ b/BoBo/Chat/Views/Components/ChatSessionActionsModifier.swift
@@ -83,7 +83,6 @@ struct ChatSessionActionsMenu: View {
     let sessionId: UUID?
     let currentTitle: String
     let onRenameRequest: () -> Void
-    let onArchiveRequest: () -> Void
     let onDeleteRequest: () -> Void
     let onReportRequest: () -> Void
 
@@ -120,11 +119,6 @@ struct ChatSessionActionsMenu: View {
             }
             .disabled(sessionId == nil)
 
-            Button("Archive") {
-                onArchiveRequest()
-            }
-            .disabled(sessionId == nil)
-
             Button("Delete", role: .destructive) {
                 onDeleteRequest()
             }
@@ -143,8 +137,6 @@ final class ChatSessionActionsCoordinator: ObservableObject {
     @Published var renameChatTitle: String = ""
     @Published var showDeleteChatConfirm: Bool = false
     @Published var showReportFlow: Bool = false
-    @Published var showArchiveChatConfirm: Bool = false
-    @Published var showArchiveChatThanks: Bool = false
 
     func requestRename(currentTitle: String) {
         renameChatTitle = currentTitle
@@ -159,9 +151,6 @@ final class ChatSessionActionsCoordinator: ObservableObject {
         showReportFlow = true
     }
 
-    func requestArchive() {
-        showArchiveChatConfirm = true
-    }
 }
 
 // MARK: - Session Actions Dialogs Modifier
@@ -205,19 +194,6 @@ struct ChatSessionActionsDialogsModifier: ViewModifier {
             }
             .sheet(isPresented: $coordinator.showReportFlow) {
                 ReportConversationFlowView(isPresented: $coordinator.showReportFlow)
-            }
-            .confirmationDialog("Archive chat?", isPresented: $coordinator.showArchiveChatConfirm, titleVisibility: .visible) {
-                Button("Archive") {
-                    coordinator.showArchiveChatThanks = true
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("This will archive the conversation. (Not wired yet)")
-            }
-            .alert("Thanks", isPresented: $coordinator.showArchiveChatThanks) {
-                Button("OK", role: .cancel) {}
-            } message: {
-                Text("Archive received. (Not wired yet)")
             }
     }
 }

--- a/BoBo/Chat/Views/Components/MessageBubbleView.swift
+++ b/BoBo/Chat/Views/Components/MessageBubbleView.swift
@@ -442,6 +442,8 @@ struct MessageBubbleView: View {
     guard !message.isToolLoading else { return false }
     // Don't show for messages generated during voice mode
     guard !message.isFromVoiceMode else { return false }
+    // Always show for stopped messages (so user can regenerate)
+    if message.wasStopped { return true }
     // Don't show while this message is still streaming (check if it's the last message and loading)
     if chatViewModel.isLoading {
       let lastAssistantMessage = chatViewModel.messages.last { !$0.isFromUser }
@@ -533,7 +535,7 @@ struct MessageBubbleView: View {
             chatViewModel.replyQuoteText = selectedText
           }
         )
-      } else if shouldShowThinkingIndicator || hasRenderableAssistantContent {
+      } else if shouldShowThinkingIndicator || hasRenderableAssistantContent || message.wasStopped {
         let hasTextContent = shouldShowThinkingIndicator || message.isToolLoading
           || message.segments.contains(where: {
             if case .text(let t) = $0 { return !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
@@ -542,7 +544,20 @@ struct MessageBubbleView: View {
         let partnerSegments = message.segments.filter { isPartnerSegment($0) }
 
         VStack(alignment: .leading, spacing: 8) {
-          if hasTextContent {
+          if message.wasStopped && !hasTextContent {
+            VStack(alignment: .leading, spacing: 8) {
+              Text("Generation stopped")
+                .font(.system(size: 15))
+                .foregroundStyle(.secondary)
+                .italic()
+                .padding(.horizontal, 4)
+                .padding(.vertical, 4)
+            }
+            .padding(12)
+            .background(AppTheme.talkToMeBubbleAI)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .foregroundColor(AppTheme.textPrimary)
+          } else if hasTextContent {
             VStack(alignment: .leading, spacing: 8) {
               if shouldShowThinkingIndicator {
                 if let thinkingText = activeStreamingThinkingText {
@@ -598,25 +613,6 @@ struct MessageBubbleView: View {
                   .padding(.top, 2)
                 }
 
-                if shouldShowAssistantActions || isActivelyStreamingMessage {
-                  AssistantMessageActionsView(
-                    messageText: plainText(from: message.segments),
-                    regenerationCount: message.regenerationCount,
-                    onRegenerate: onRegenerate,
-                    onToast: onToast,
-                    thinkingSummary: message.thinkingSummary,
-                    onToggleThinking: {
-                      withAnimation(.easeInOut(duration: 0.2)) {
-                        isThinkingExpanded.toggle()
-                      }
-                    }
-                  )
-                  .opacity(shouldShowAssistantActions ? 1 : 0)
-                  .offset(y: shouldShowAssistantActions ? 0 : 6)
-                  .allowsHitTesting(shouldShowAssistantActions)
-                  .animation(.easeOut(duration: 0.35), value: shouldShowAssistantActions)
-                }
-
                 if shouldShowVoiceRespondedLabel {
                   Text(
                     "\(voiceGhostDisplayName) responded at \(message.timestamp.formatted(date: .omitted, time: .shortened))"
@@ -632,6 +628,27 @@ struct MessageBubbleView: View {
             .background(AppTheme.talkToMeBubbleAI)
             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
             .foregroundColor(AppTheme.textPrimary)
+          }
+
+          // Action buttons — rendered outside the bubble so they show
+          // for both stopped (empty) and normal messages.
+          if shouldShowAssistantActions || isActivelyStreamingMessage {
+            AssistantMessageActionsView(
+              messageText: plainText(from: message.segments),
+              regenerationCount: message.regenerationCount,
+              onRegenerate: onRegenerate,
+              onToast: onToast,
+              thinkingSummary: message.thinkingSummary,
+              onToggleThinking: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                  isThinkingExpanded.toggle()
+                }
+              }
+            )
+            .opacity(shouldShowAssistantActions ? 1 : 0)
+            .offset(y: shouldShowAssistantActions ? 0 : 6)
+            .allowsHitTesting(shouldShowAssistantActions)
+            .animation(.easeOut(duration: 0.35), value: shouldShowAssistantActions)
           }
 
           // Partner segments rendered outside the AI bubble

--- a/BoBo/Chat/Views/MessagesListView.swift
+++ b/BoBo/Chat/Views/MessagesListView.swift
@@ -121,11 +121,21 @@ struct MessagesListView: View {
     var body: some View {
         ScrollViewReader { scrollProxy in
         ScrollView {
-            if messages.isEmpty && chatViewModel.sessionId == nil {
-                chatEmptyState
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 120)
+            Group {
+                if messages.isEmpty && !chatViewModel.isSpeakModeActive && chatViewModel.sessionId == nil {
+                    chatEmptyState
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 180)
+                        .transition(.scale(scale: 0.6).combined(with: .opacity))
+                } else if messages.isEmpty && !chatViewModel.isSpeakModeActive && hasBuddy {
+                    buddyImageEmptyState
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 180)
+                        .transition(.scale(scale: 0.6).combined(with: .opacity))
+                }
             }
+            .animation(.easeOut(duration: 0.35), value: messages.isEmpty)
+            .animation(.easeOut(duration: 0.35), value: chatViewModel.isSpeakModeActive)
 
             LazyVStack(spacing: 18) {
                 ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
@@ -392,10 +402,58 @@ struct MessagesListView: View {
         buddyExplicitlyChosen
     }
 
+    private static let emptyStatePhrases = [
+        "Let's start chatting!",
+        "What's on your mind?",
+        "I'm all ears!",
+        "Ready when you are!",
+        "Go ahead, say anything!"
+    ]
+
+    @State private var emptyStatePhrase: String = emptyStatePhrases.randomElement()!
+
     @ViewBuilder
     private var chatEmptyState: some View {
         if !hasBuddy {
             buddyPickerEmptyState
+        } else {
+            buddyImageEmptyState
+        }
+    }
+
+    private var ghostVideoName: String? {
+        ElevenLabsVoiceSuggestionsView.ghostVideoName(for: currentBuddyName)
+    }
+
+    private var hasGhostVideo: Bool {
+        guard let name = ghostVideoName, !name.isEmpty else { return false }
+        return Bundle.main.url(forResource: name, withExtension: "mp4") != nil
+    }
+
+    @ViewBuilder
+    private var buddyImageEmptyState: some View {
+        VStack(spacing: 16) {
+            if hasGhostVideo, let videoName = ghostVideoName {
+                TransparentVideoPlayerView(
+                    videoName: videoName,
+                    videoExtension: "mp4",
+                    startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[videoName] ?? 0
+                )
+                .frame(width: 180, height: 180)
+            } else if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: currentBuddyName) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 180, height: 180)
+            } else {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 80))
+                    .foregroundStyle(Color(.tertiaryLabel))
+            }
+
+            Text(emptyStatePhrase)
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.primary)
         }
     }
 
@@ -450,7 +508,17 @@ struct MessagesListView: View {
 
     private func ghostCard(name: String) -> some View {
         Group {
-            if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: name) {
+            let videoName = ElevenLabsVoiceSuggestionsView.ghostVideoName(for: name)
+            let hasVideo = videoName.map { Bundle.main.url(forResource: $0, withExtension: "mp4") != nil } ?? false
+
+            if hasVideo, let videoName {
+                TransparentVideoPlayerView(
+                    videoName: videoName,
+                    videoExtension: "mp4",
+                    startTime: ElevenLabsVoiceSuggestionsView.ghostStartTimes[videoName] ?? 0
+                )
+                .frame(width: 110, height: 110)
+            } else if let uiImage = ElevenLabsVoiceSuggestionsView.ghostUIImage(for: name) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()

--- a/BoBo/Diary/Views/DiaryView.swift
+++ b/BoBo/Diary/Views/DiaryView.swift
@@ -973,6 +973,7 @@ private struct JournalTabBar: View {
         }
       }
       .clipShape(Capsule(style: .continuous))
+      .contentShape(Capsule(style: .continuous))
       .overlay(
         Capsule(style: .continuous)
           .stroke(Color(.separator).opacity(isActive ? 0.0 : 0.25), lineWidth: isActive ? 0 : 0.5)
@@ -1483,16 +1484,39 @@ private struct JournalListTab: View {
         }
 
         if entries.isEmpty {
-          VStack(spacing: 10) {
+          VStack(spacing: 14) {
             Spacer().frame(height: 36)
-            Image(systemName: "book.closed")
-              .font(.system(size: 28, weight: .semibold))
-              .foregroundStyle(.secondary)
-            Text("No entries yet")
-              .font(.system(size: 16, weight: .semibold))
-            Text("Tap + to add your first entry.")
+            ZStack(alignment: .topTrailing) {
+              RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemFill))
+                .frame(width: 60, height: 60)
+                .overlay(
+                  Image(systemName: "book.closed.fill")
+                    .font(.system(size: 26))
+                    .foregroundStyle(Color(.label))
+                )
+
+              Circle()
+                .fill(Color.accentColor)
+                .frame(width: 18, height: 18)
+                .overlay(
+                  Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white)
+                )
+                .offset(x: 4, y: -4)
+            }
+            .padding(.top, 8)
+
+            Text("No Entries Yet")
+              .font(.system(size: 19, weight: .bold))
+              .foregroundStyle(Color(.label))
+
+            Text("Tap the + button below to add your first entry and start capturing your thoughts!")
               .font(.system(size: 14))
-              .foregroundStyle(.secondary)
+              .foregroundStyle(Color(.secondaryLabel))
+              .multilineTextAlignment(.center)
+              .padding(.horizontal, 16)
           }
           .frame(maxWidth: .infinity)
         } else if filteredEntries.isEmpty {
@@ -1560,9 +1584,7 @@ private struct JournalListTab: View {
 // MARK: - ToDo list tab
 
 private let diaryTodoStorageKey = "diary_todo_items"
-private let diaryDefaultTodoItems = [
-  DiaryTodoItem(title: "Plan tomorrow's top priority")
-]
+private let diaryDefaultTodoItems: [DiaryTodoItem] = []
 
 private struct JournalTodoTab: View {
   @Binding var todoItems: [DiaryTodoItem]

--- a/BoBo/Home/Views/HomeView.swift
+++ b/BoBo/Home/Views/HomeView.swift
@@ -831,31 +831,56 @@ private struct NotificationsView: View {
             .padding(.bottom, 8)
           }
 
+          if groupedNotifications.isEmpty && apns.isPushEnabled {
+            VStack(spacing: 14) {
+              if !searchText.isEmpty {
+                Image(systemName: "magnifyingglass")
+                  .font(.system(size: 56))
+                  .foregroundStyle(Color(.tertiaryLabel))
+                Text("No results for \"\(searchText)\"")
+                  .font(.system(size: 15, weight: .medium))
+                  .foregroundStyle(Color(.secondaryLabel))
+              } else {
+                ZStack(alignment: .topTrailing) {
+                  RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(.secondarySystemFill))
+                    .frame(width: 60, height: 60)
+                    .overlay(
+                      Image(systemName: "bell.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(.label))
+                    )
+
+                  Circle()
+                    .fill(Color.green)
+                    .frame(width: 18, height: 18)
+                    .overlay(
+                      Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                    )
+                    .offset(x: 4, y: -4)
+                }
+                .padding(.top, 8)
+
+                Text("All Caught Up")
+                  .font(.system(size: 19, weight: .bold))
+                  .foregroundStyle(Color(.label))
+
+                Text("No notifications right now. We\u{2019}ll let you know when something comes in.")
+                  .font(.system(size: 14))
+                  .foregroundStyle(Color(.secondaryLabel))
+                  .multilineTextAlignment(.center)
+                  .padding(.horizontal, 16)
+              }
+            }
+            .frame(maxWidth: .infinity)
+          }
+
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
         .padding(.bottom, 24)
-      }
-
-      if groupedNotifications.isEmpty && apns.isPushEnabled {
-        VStack(spacing: 12) {
-          if !searchText.isEmpty {
-            Image(systemName: "magnifyingglass")
-              .font(.system(size: 56))
-              .foregroundStyle(Color(.tertiaryLabel))
-            Text("No results for \"\(searchText)\"")
-              .font(.system(size: 15, weight: .medium))
-              .foregroundStyle(Color(.secondaryLabel))
-          } else {
-            Image(systemName: "bell.slash")
-              .font(.system(size: 56))
-              .foregroundStyle(Color(.tertiaryLabel))
-            Text("No notifications yet")
-              .font(.system(size: 15, weight: .medium))
-              .foregroundStyle(Color(.secondaryLabel))
-          }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
     .navigationTitle("Notifications")

--- a/BoBo/Services/Backend/DeepgramStreamingSTTService.swift
+++ b/BoBo/Services/Backend/DeepgramStreamingSTTService.swift
@@ -61,6 +61,13 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
     private let keepAliveIntervalSeconds: TimeInterval = 10.0
     private var echoGateKeepAliveTask: Task<Void, Never>?
 
+    /// Fires `lastFinalUtterance` if `speech_final` hasn't arrived within
+    /// this interval after the most recent `is_final` transcript part.
+    /// Helps in noisy environments where background sound prevents Deepgram's
+    /// VAD from detecting end-of-speech.
+    private var speechFinalFallbackTask: Task<Void, Never>?
+    private let speechFinalFallbackDelayNs: UInt64 = 1_500_000_000 // 1.5s
+
     init(urlSession: URLSession = .shared) {
         self.urlSession = urlSession
     }
@@ -151,6 +158,8 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
         SharedAudioEngine.shared.removeInputTap()
         stopKeepAlive()
         stopEchoGateKeepAlive()
+        speechFinalFallbackTask?.cancel()
+        speechFinalFallbackTask = nil
         isConnected = false
         isRecording = false
         isPaused = false
@@ -214,6 +223,8 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
     func stopRecording() {
         isRecording = false
         isPaused = false
+        speechFinalFallbackTask?.cancel()
+        speechFinalFallbackTask = nil
         SharedAudioEngine.shared.removeInputTap()
         flushBufferedAudioIfPossible()
         sendJSONEvent(["type": "finalize"])
@@ -349,16 +360,49 @@ final class DeepgramStreamingSTTService: ObservableObject, @unchecked Sendable {
             }
             currentInterim = ""
             updatePresentedTranscript()
+
+            // In noisy environments (e.g. cafes), Deepgram's VAD may never
+            // fire `speech_final` because background noise is mistaken for
+            // continued speech. Start a fallback timer after each `is_final`
+            // that contains real content — if `speech_final` doesn't arrive
+            // within the window we treat the accumulated parts as a complete
+            // utterance and fire it ourselves.
+            if !trimmed.isEmpty && transcriptAggregation == .perUtterance {
+                speechFinalFallbackTask?.cancel()
+                speechFinalFallbackTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: self?.speechFinalFallbackDelayNs ?? 1_500_000_000)
+                    guard !Task.isCancelled else { return }
+                    guard let self else { return }
+                    let utterance = self.currentUtteranceFinalParts
+                        .joined(separator: " ")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !utterance.isEmpty else { return }
+                    print("[VoiceAgent][STT] speechFinal FALLBACK (timeout) — utterance: \"\(utterance.prefix(80))\" isConnected=\(self.isConnected)")
+                    self.isUserSpeaking = false
+                    self.lastFinalUtterance = utterance
+                    self.currentUtteranceFinalParts = []
+                    if self.transcriptAggregation == .perUtterance {
+                        self.committedParts = []
+                        self.currentInterim = ""
+                    }
+                }
+            }
         } else {
             // Ignore transient empty interim packets to prevent transcript flicker.
             if !trimmed.isEmpty {
                 currentInterim = trimmed
                 updatePresentedTranscript()
+                // User is still speaking — postpone the fallback timer so we
+                // don't fire mid-sentence.
+                speechFinalFallbackTask?.cancel()
+                speechFinalFallbackTask = nil
             }
             isUserSpeaking = !trimmed.isEmpty
         }
 
         if speechFinal == true {
+            speechFinalFallbackTask?.cancel()
+            speechFinalFallbackTask = nil
             isUserSpeaking = false
             let utterance = currentUtteranceFinalParts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             if !utterance.isEmpty {

--- a/BoBo/Services/GRDB-Service/ChatStore.swift
+++ b/BoBo/Services/GRDB-Service/ChatStore.swift
@@ -22,6 +22,7 @@ struct ChatMessageRecord: Codable, FetchableRecord, PersistableRecord {
     var ghost_name: String?
     var thinking_summary: String?
     var is_voice_mode: Bool
+    var was_stopped: Bool
 }
 
 struct ChatAttachmentRecord: Codable, FetchableRecord, PersistableRecord {
@@ -494,6 +495,34 @@ final class ChatStore {
         } catch {}
     }
 
+    /// Persists a stopped assistant message to GRDB so it survives reconciliation.
+    func persistStoppedMessage(messageId: UUID, sessionId: UUID, userId: UUID, content: String, isVoiceMode: Bool, ghostName: String?) async {
+        let now = isoFormatter.string(from: Date())
+        do {
+            try await dbQueue.write { db in
+                // Ensure session row exists
+                try db.execute(
+                    sql: "INSERT OR IGNORE INTO sessions (id, title, last_message_at, last_message_content) VALUES (?, NULL, NULL, NULL)",
+                    arguments: [sessionId.uuidString]
+                )
+                let rec = ChatMessageRecord(
+                    id: messageId.uuidString,
+                    session_id: sessionId.uuidString,
+                    user_id: userId.uuidString,
+                    role: "assistant",
+                    content: content,
+                    created_at: now,
+                    regeneration_count: 0,
+                    ghost_name: ghostName,
+                    thinking_summary: nil,
+                    is_voice_mode: isVoiceMode,
+                    was_stopped: true
+                )
+                try rec.save(db)
+            }
+        } catch {}
+    }
+
     func loadMessages(sessionId: UUID, currentUserId: UUID) async -> [ChatMessage] {
         let sid = sessionId.uuidString
         do {
@@ -550,6 +579,7 @@ final class ChatStore {
                 if let gn = r.ghost_name { msg.ghostName = gn }
                 if let ts = r.thinking_summary, !ts.isEmpty { msg.thinkingSummary = ts }
                 if r.is_voice_mode { msg.isFromVoiceMode = true }
+                if r.was_stopped { msg.wasStopped = true }
                 return msg
             }
         } catch {
@@ -581,6 +611,14 @@ final class ChatStore {
 
                 var collectedRelpaths: [String] = []
                 for mid in orphanIds {
+                    // Preserve stopped messages (local-only, user cancelled generation)
+                    let isStopped = try Bool.fetchOne(
+                        db,
+                        sql: "SELECT was_stopped FROM messages WHERE id = ?",
+                        arguments: [mid]
+                    ) ?? false
+                    if isStopped { continue }
+
                     // Preserve messages with pending outbox items
                     let pendingCount = try Int.fetchOne(
                         db,
@@ -735,7 +773,8 @@ final class ChatStore {
                         regeneration_count: existing?.regeneration_count ?? 0,
                         ghost_name: resolvedGhostName,
                         thinking_summary: existing?.thinking_summary,
-                        is_voice_mode: resolvedVoiceMode
+                        is_voice_mode: resolvedVoiceMode,
+                        was_stopped: existing?.was_stopped ?? false
                     )
                     try rec.save(db)
                 }

--- a/BoBo/Services/GRDB-Service/LocalDatabase.swift
+++ b/BoBo/Services/GRDB-Service/LocalDatabase.swift
@@ -198,6 +198,12 @@ final class LocalDatabase {
             }
         }
 
+        migrator.registerMigration("messages_add_was_stopped") { db in
+            try db.alter(table: "messages") { t in
+                t.add(column: "was_stopped", .boolean).notNull().defaults(to: false)
+            }
+        }
+
         migrator.registerMigration("create_diary_entries") { db in
             try db.create(table: "diary_entries", ifNotExists: true) { t in
                 t.column("id", .text).primaryKey()


### PR DESCRIPTION
## Summary

Comprehensive fixes for chat streaming, UI empty states, and session management before internal testing:

- **Voice & Streaming**: Fixed dictation defaulting to off, prevented duplicate startSpeakMode calls, made stop-generation preserve partial text and show action buttons
- **Empty States**: Added buddy ghost images with animated mp4 videos, fixed notifications positioning, added green checkmark to "All Caught Up"
- **Session Handling**: Fixed 403 "Forbidden" errors for orphan local sessions using in-memory tracking, added "Generation stopped" message persistence
- **Critical Race Fix**: Added stale stream event guard to prevent session rekeying when stopping mid-generation
- **Removed Features**: Cleaned up non-functional Archive button from chat menu

## Test Plan

- [ ] Voice mode activates correctly and doesn't trigger duplicate calls
- [ ] Stopped streams show action buttons with "Generation stopped" message
- [ ] Buddy image appears in empty chat after selection
- [ ] Notifications empty state displays correctly with checkmark
- [ ] No 403 errors when sending messages in new chats
- [ ] "Generation stopped" messages persist across app restarts
- [ ] Stop-generating doesn't corrupt other chat sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)